### PR TITLE
Sprint 3: advert matching and the cover letter

### DIFF
--- a/.agents/harness/stacks/typescript-node.md
+++ b/.agents/harness/stacks/typescript-node.md
@@ -137,7 +137,9 @@ present, reading order, no raster images, a clean start to page two, measured gr
 monochrome ones, canonical spelling of hyphenated compounds, block integrity in extraction, every skill
 category still attached to its own list, and every web address recoverable from the text layer.
 It
-rewrites `docs/PDF_AUDIT.md`. Every variant must stay at 11/11.
+rewrites `docs/PDF_AUDIT.md`. Every CV variant must stay at 11/11. A cover letter is a different document and is scored
+on six of its own: format, exactly one page, its recipient and subject present, no raster,
+monochrome, and canonical compounds. The `-cover` in a filename is what tells them apart.
 
 `npm run audit:print` scores the other artefact — what the browser prints — on twelve checks,
 measured on the rasterised page rather than on the stylesheet, and rewrites `docs/PRINT_AUDIT.md`.

--- a/adapters/LetterLayout.js
+++ b/adapters/LetterLayout.js
@@ -1,0 +1,174 @@
+/**
+ * A cover letter on a page, laid out to DIN 5008 form B.
+ *
+ * The sibling of `adapters/PdfLayout.js`, and it speaks the same dialect: points, columns,
+ * canvas rectangles, style names. It takes the theme of whichever CV layout it accompanies,
+ * because a letter set in a different typeface to its CV reads as two documents from two
+ * people, and the pair arrives in one envelope.
+ *
+ * DIN 5008 is not decoration in the German market: the address block sits where a window
+ * envelope shows it, and a letter that ignores that is a letter someone has to re-fold. Form B
+ * is the one with the larger information field, which is what a letter with a reference needs.
+ *
+ * Millimetres are the standard's unit and points are pdfmake's, so every constant below is
+ * named in the standard's terms and converted once.
+ */
+const MM = 72 / 25.4;
+
+/** Form B, from the standard. The left margin is what makes the window line up. */
+const LEFT = 24.1 * MM;
+const RIGHT = 20 * MM;
+const TOP = 20 * MM;
+const BOTTOM = 20 * MM;
+/** The address field begins 45mm down the page in form B, and is 85mm wide. */
+const ADDRESS_TOP = 45 * MM;
+const ADDRESS_WIDTH = 85 * MM;
+/** The return-address line above the recipient, which the standard sets at 5mm. */
+const RETURN_HEIGHT = 5 * MM;
+/** The subject sits 98.46mm down in form B; the body follows two lines later. */
+const SUBJECT_TOP = 98.46 * MM;
+
+export class LetterLayout {
+  /**
+   * @param {Object} letter - A CoverLetter
+   * @param {Object} options - `{ identity, format, theme, typography, t, locale }`
+   * @returns {Object} A pdfmake document definition
+   */
+  compose(letter, { identity, format, theme, typography, t, locale = 'en' } = {}) {
+    const bodyWidth = format.width - LEFT - RIGHT;
+
+    return {
+      pageSize: { width: format.width, height: format.height },
+      pageMargins: [LEFT, TOP, RIGHT, BOTTOM],
+      info: {
+        title: `${identity.name} — ${letter.subject || t('cv:letter.subject')}`,
+        author: identity.name
+      },
+      ...typography,
+      content: [
+        this.sender(identity, theme),
+        this.addressBlock(letter, identity, theme, bodyWidth),
+        this.dateLine(letter, identity, theme, locale),
+        this.subjectLine(letter, theme, t),
+        ...this.bodyBlocks(letter, theme, t),
+        this.closing(letter, identity, theme, t),
+        ...this.attachments(letter, theme, t)
+      ]
+    };
+  }
+
+  /**
+   * The sender, above the address field.
+   *
+   * Small and grey on purpose: it is there so the letter can be returned, not so it can be
+   * read. The standard gives it a single 5mm line.
+   */
+  sender(identity, theme) {
+    const parts = [identity.name, identity.location, identity.email, identity.phone].filter(Boolean);
+    return {
+      text: parts.join(' · '),
+      fontSize: 7.5,
+      color: theme.muted,
+      decoration: 'underline',
+      decorationColor: theme.soft,
+      margin: [0, ADDRESS_TOP - TOP - RETURN_HEIGHT, 0, 3]
+    };
+  }
+
+  /**
+   * Who the letter is for.
+   *
+   * Every line the data wrote, and no line it did not: a letter addressed to a company with no
+   * name on it is a letter addressed to nobody, and the model reports that rather than filling
+   * it in. Nothing here invents a recipient.
+   */
+  addressBlock(letter, identity, theme, bodyWidth) {
+    const lines = [
+      letter.recipient.company,
+      letter.recipient.name,
+      letter.recipient.role,
+      ...letter.recipient.address
+    ].filter(Boolean);
+
+    return {
+      columns: [
+        { width: ADDRESS_WIDTH, stack: lines.map((line) => ({ text: line })), color: theme.ink },
+        { width: bodyWidth - ADDRESS_WIDTH, text: '' }
+      ],
+      margin: [0, 0, 0, 0]
+    };
+  }
+
+  /**
+   * The date, right-aligned, with the reference beneath it.
+   *
+   * `Intl` formats it, never a hand-written pattern: `AGENTS.md` gives dates to `Intl` and a
+   * German letter dated in American order is a letter that was not written for its reader.
+   */
+  dateLine(letter, identity, theme, locale) {
+    const stack = [];
+    if (letter.date) {
+      const parsed = new Date(letter.date);
+      const formatted = Number.isNaN(parsed.valueOf())
+        ? letter.date
+        : new Intl.DateTimeFormat(locale, { year: 'numeric', month: 'long', day: 'numeric' }).format(parsed);
+      stack.push({ text: [identity.location, formatted].filter(Boolean).join(', '), alignment: 'right' });
+    }
+    if (letter.reference) {
+      stack.push({ text: letter.reference, alignment: 'right', style: 'meta' });
+    }
+    return { stack, margin: [0, SUBJECT_TOP - ADDRESS_TOP - 40, 0, 12] };
+  }
+
+  /** The one line a reader decides on. Bold, and never longer than the measure. */
+  subjectLine(letter, theme, t) {
+    return {
+      text: letter.subject || t('cv:letter.subject'),
+      bold: true,
+      color: theme.ink,
+      margin: [0, 0, 0, 14]
+    };
+  }
+
+  /**
+   * The salutation, the opening, the body.
+   *
+   * The salutation's wording comes from the catalogue and the name from the model: the domain
+   * says who is addressed and never how, so a German letter opens the way a German letter does.
+   */
+  bodyBlocks(letter, theme, t) {
+    const salutation = letter.addressee
+      ? `${t('cv:letter.salutationNamed')} ${letter.addressee},`
+      : `${t('cv:letter.salutationAnonymous')},`;
+
+    return [
+      { text: salutation, margin: [0, 0, 0, 10] },
+      ...[letter.opening, ...letter.body].filter(Boolean)
+        .map((paragraph) => ({ text: paragraph, alignment: 'left', margin: [0, 0, 0, 8] }))
+    ];
+  }
+
+  /** The close, a gap where a signature goes, and the name under it. */
+  closing(letter, identity, theme, t) {
+    return {
+      stack: [
+        ...(letter.closing ? [{ text: letter.closing, margin: [0, 4, 0, 10] }] : []),
+        { text: t('cv:letter.closing'), margin: [0, 0, 0, 34] },
+        { text: letter.signature || identity.name, color: theme.ink }
+      ],
+      // The whole close travels together: a name orphaned onto a second page is the one
+      // pagination failure a reader always notices.
+      unbreakable: true
+    };
+  }
+
+  /** What travels with the letter, named so a reader can tell whether it arrived. */
+  attachments(letter, theme, t) {
+    if (!letter.attachments.length) return [];
+    return [{
+      text: `${t('cv:letter.attachments')}: ${letter.attachments.join(', ')}`,
+      style: 'meta',
+      margin: [0, 24, 0, 0]
+    }];
+  }
+}

--- a/core/AdvertMatcher.js
+++ b/core/AdvertMatcher.js
@@ -1,0 +1,206 @@
+import { AdvertLexicon } from '../domain/AdvertLexicon.js';
+import { fold } from '../domain/fold.js';
+
+/** Tokens that survive: `CI/CD`, `C++`, `.NET`, `Objective-C`, `Swift 6`. */
+const TOKEN = /\.?[A-Za-z0-9][A-Za-z0-9+#./-]*/g;
+
+/** A term that carries a capital inside it, a digit, or a symbol is probably a technology. */
+const TECHNICAL = /[A-Z].*[A-Z]|[0-9]|[+#/.]/;
+
+/**
+ * What an advert asks for, and where the CV answers it.
+ *
+ * Two halves, and the second is the one worth having. Extracting terms is a frequency exercise
+ * anyone can do. Placing them is the part that changes a decision: a term found in the prose of
+ * a role is evidence, and the same term found only in a list of skills is a claim.
+ *
+ * Matching runs against what a parser **recovered**, never against the authored JSON. A term the
+ * layout shredded counts as absent, which is the whole reason this sits downstream of the parser
+ * rather than beside it.
+ */
+export class AdvertMatcher {
+  /**
+   * Rank what the advert asks for.
+   *
+   * The ranking is frequency, weighted by how specific a term looks and by which section of the
+   * advert it came from. **It is not TF-IDF** — there is no corpus here to compute an inverse
+   * document frequency against, and borrowing the name for a heuristic would be claiming a
+   * precision it does not have.
+   * @param {string} text - The advert
+   * @param {number} [limit] - How many terms to keep
+   * @returns {{terms: Array, language: Object|null}} Ranked terms
+   */
+  static extractTerms(text, limit = 30) {
+    const lines = String(text ?? '').split(/\r?\n/);
+    const counts = new Map();
+    let section = null;
+
+    for (const line of lines) {
+      const heading = AdvertLexicon.headingKind(line);
+      if (heading) {
+        section = heading;
+        continue;
+      }
+      if (!line.trim() || AdvertLexicon.isBoilerplate(line)) continue;
+
+      const words = (line.match(TOKEN) || [])
+        .map((word) => word.replace(/[.,;:]+$/, ''))
+        .filter(Boolean);
+
+      for (let size = 1; size <= 3; size += 1) {
+        for (let start = 0; start + size <= words.length; start += 1) {
+          const phrase = words.slice(start, start + size).join(' ');
+          if (!AdvertMatcher.keeps(phrase, words.slice(start, start + size))) continue;
+          const key = fold(phrase);
+          const entry = counts.get(key) || { term: phrase, count: 0, required: false, size };
+          entry.count += section === 'offer' ? 0.25 : 1;
+          entry.required = entry.required || section === 'required';
+          counts.set(key, entry);
+        }
+      }
+    }
+
+    const ranked = [...counts.values()]
+      .map((entry) => ({
+        term: entry.term,
+        required: entry.required,
+        // No bonus for length. Rewarding longer phrases made the winner of every family the
+        // most verbose member of it — `Integrate AI-powered features through` rather than
+        // `AI-powered` — and a requirement is easier to answer stated plainly.
+        weight: entry.count * (TECHNICAL.test(entry.term) ? 2 : 1)
+      }))
+      .sort((a, b) => b.weight - a.weight || a.term.localeCompare(b.term));
+
+    return { terms: AdvertMatcher.dedupe(ranked, limit), language: AdvertLexicon.languageOf(text) };
+  }
+
+  /**
+   * One entry per idea, not one per window.
+   *
+   * Sliding an n-gram over `Integrate AI-powered features through backend APIs` produces
+   * `AI-powered`, `AI-powered features`, `Integrate AI-powered features` and three more, all
+   * ranked adjacently and all the same requirement. Kept as they are they crowd out every
+   * other term in the advert — which is what happened the first time this ran against a real
+   * one: five variants of one phrase, and `Swift` nowhere in the top twenty-four.
+   *
+   * Highest-ranked member wins and swallows the family. A term is dropped when it contains, or
+   * is contained by, one already kept.
+   * @param {Array} ranked - Terms, best first
+   * @param {number} limit - How many to keep
+   * @returns {Array} Terms, deduplicated
+   */
+  static dedupe(ranked, limit) {
+    const kept = [];
+    for (const entry of ranked) {
+      if (kept.length >= limit) break;
+      const folded = fold(entry.term);
+      const overlaps = kept.some(({ term }) => {
+        const other = fold(term);
+        if (AdvertMatcher.contains(folded, other) || AdvertMatcher.contains(other, folded)) return true;
+        // Two phrases sharing a pair of adjacent words are one idea said twice: `App Store
+        // quality` and `high App Store` are not two requirements.
+        const shared = AdvertMatcher.bigrams(folded).filter((pair) => AdvertMatcher.bigrams(other).includes(pair));
+        return shared.length > 0;
+      });
+      if (overlaps) continue;
+      kept.push({ term: entry.term, required: entry.required });
+    }
+    return kept;
+  }
+
+  /** A phrase worth ranking: not a stopword, not boilerplate, not a bare number. */
+  static keeps(phrase, words) {
+    if (words.some((word) => AdvertLexicon.isStopword(word))) return false;
+    if (AdvertLexicon.isBoilerplate(phrase)) return false;
+    if (/^[\d\W]+$/.test(phrase)) return false;
+    return phrase.length >= 2 && phrase.length <= 60;
+  }
+
+  /**
+   * Where the CV answers each term, at its strongest.
+   *
+   * The order is the point. Prose beats a list, because a term in the prose of a role is a
+   * claim with a context, a date and an employer attached, while the same term in a list of
+   * skills is a word. An advert asks for the first and screens on the second.
+   * @param {Array} terms - From `extractTerms`
+   * @param {Object} recovered - A RecoveredCv
+   * @returns {{terms: Array}} The terms with their evidence
+   */
+  static match(terms, recovered) {
+    const prose = AdvertMatcher.prose(recovered);
+    const headline = AdvertMatcher.headline(recovered);
+    const listed = AdvertMatcher.listed(recovered);
+
+    return {
+      terms: terms.map((entry) => {
+        const inProse = AdvertMatcher.appears(entry.term, prose.text);
+        if (inProse) return { ...entry, evidence: 'inProse', match: inProse, where: prose.whereOf(entry.term) };
+        const inHeadline = AdvertMatcher.appears(entry.term, headline);
+        if (inHeadline) return { ...entry, evidence: 'inHeadline', match: inHeadline, where: 'the role line' };
+        const inList = AdvertMatcher.appears(entry.term, listed);
+        if (inList) return { ...entry, evidence: 'inSkillsOnly', match: inList, where: 'the skills list' };
+        return { ...entry, evidence: 'absent', match: null, where: null };
+      })
+    };
+  }
+
+  /** Everything a role or the summary actually claims, with the role each fragment came from. */
+  static prose(recovered) {
+    const blocks = [
+      ...(recovered.profile ? [{ where: 'profile', text: recovered.profile }] : []),
+      ...recovered.experience.map((role, index) => ({
+        where: role.employer?.value || role.title?.value || `role ${index + 1}`,
+        text: [role.title?.value, role.bodyText].filter(Boolean).join(' ')
+      }))
+    ];
+    return {
+      text: blocks.map((block) => block.text).join('\n'),
+      // Which role carried it, so a finding can quote where the claim actually lives.
+      whereOf: (term) => blocks.find((block) => AdvertMatcher.appears(term, block.text))?.where || null
+    };
+  }
+
+  /** The name line and the role line: the first thing read, and the least evidenced. */
+  static headline(recovered) {
+    return [recovered.identity.title?.value, recovered.identity.name?.value].filter(Boolean).join(' ');
+  }
+
+  /** Skills, certifications and interests — where a word can appear without a claim behind it. */
+  static listed(recovered) {
+    return [
+      ...recovered.skills.flatMap((group) => [group.category, ...group.items]),
+      ...recovered.certifications.map((entry) => entry.text)
+    ].filter(Boolean).join('\n');
+  }
+
+  /**
+   * Whether a term appears, as itself or through the curated synonym table.
+   *
+   * Whole-word, because `AI` inside `maintain` is not a mention of artificial intelligence and
+   * a matcher that counts it reports a fit the CV does not have.
+   * @param {string} term - What the advert asked for
+   * @param {string} haystack - Where to look
+   * @returns {'exact'|'synonym'|null} How it was found
+   */
+  static appears(term, haystack) {
+    const text = fold(haystack);
+    if (AdvertMatcher.contains(text, fold(term))) return 'exact';
+
+    for (const form of AdvertLexicon.formsOf(term)) {
+      if (form !== fold(term) && AdvertMatcher.contains(text, form)) return 'synonym';
+    }
+    return null;
+  }
+
+  /** Every pair of adjacent words in a folded phrase. */
+  static bigrams(phrase) {
+    const words = phrase.split(' ');
+    return words.slice(1).map((word, index) => `${words[index]} ${word}`);
+  }
+
+  static contains(haystack, needle) {
+    if (!needle) return false;
+    const escaped = needle.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    return new RegExp(`(^|[^a-z0-9])${escaped}($|[^a-z0-9])`).test(haystack);
+  }
+}

--- a/core/AdvertMatcher.js
+++ b/core/AdvertMatcher.js
@@ -38,7 +38,9 @@ export class AdvertMatcher {
     for (const line of lines) {
       const heading = AdvertLexicon.headingKind(line);
       if (heading) {
-        section = heading;
+        // A neutral heading organises the advert without demanding anything, so it does not
+        // change what the terms under it are worth — but its own words are never terms.
+        if (heading !== 'neutral') section = heading;
         continue;
       }
       if (!line.trim() || AdvertLexicon.isBoilerplate(line)) continue;
@@ -124,23 +126,71 @@ export class AdvertMatcher {
    * skills is a word. An advert asks for the first and screens on the second.
    * @param {Array} terms - From `extractTerms`
    * @param {Object} recovered - A RecoveredCv
+   * @param {Object} [document] - The CvDocument, to say whether the CV claims it at all
    * @returns {{terms: Array}} The terms with their evidence
    */
-  static match(terms, recovered) {
+  static match(terms, recovered, document = null) {
+    const authored = document ? AdvertMatcher.authoredText(document) : null;
     const prose = AdvertMatcher.prose(recovered);
     const headline = AdvertMatcher.headline(recovered);
     const listed = AdvertMatcher.listed(recovered);
 
     return {
-      terms: terms.map((entry) => {
+      terms: terms.map((entry) => AdvertMatcher.place(entry, prose, headline, listed, authored))
+    };
+  }
+
+  /**
+   * One term, placed — and, when the source is available, told apart from a term the CV
+   * simply does not claim.
+   *
+   * This is the distinction the whole tool exists for. A term the CV writes but the artefact
+   * lost is a **layout defect**: the renderer is wrong and the copy is fine. A term the CV
+   * never wrote is a **content gap**: a human decides whether it is worth claiming, and the
+   * tool must never suggest that it is.
+   */
+  static place(entry, prose, headline, listed, authored) {
+    const claimed = authored === null ? null : AdvertMatcher.appears(entry.term, authored) !== null;
+    const at = (evidence, match, where) => ({ ...entry, evidence, match, where, authored: claimed });
+    {
         const inProse = AdvertMatcher.appears(entry.term, prose.text);
-        if (inProse) return { ...entry, evidence: 'inProse', match: inProse, where: prose.whereOf(entry.term) };
+        if (inProse) return at('inProse', inProse, prose.whereOf(entry.term));
         const inHeadline = AdvertMatcher.appears(entry.term, headline);
-        if (inHeadline) return { ...entry, evidence: 'inHeadline', match: inHeadline, where: 'the role line' };
+        if (inHeadline) return at('inHeadline', inHeadline, 'the role line');
         const inList = AdvertMatcher.appears(entry.term, listed);
-        if (inList) return { ...entry, evidence: 'inSkillsOnly', match: inList, where: 'the skills list' };
-        return { ...entry, evidence: 'absent', match: null, where: null };
-      })
+        if (inList) return at('inSkillsOnly', inList, 'the skills list');
+        return at('absent', null, null);
+    }
+  }
+
+  /** Everything the authored profile says, so a lost term can be told from an unwritten one. */
+  static authoredText(document) {
+    return [
+      document.identity.title, document.identity.subtitle, document.profile,
+      ...(document.careerHighlights || []),
+      ...document.experience.flatMap((job) => [job.title, job.company, job.summary, ...(job.highlights || [])]),
+      ...document.skills.flatMap((group) => [group.category, ...group.items.map((item) => item.name)]),
+      ...document.certifications.flatMap((item) => [item.name, item.description])
+    ].filter(Boolean).join('\n');
+  }
+
+  /**
+   * Which required terms appear in the opening of the extracted text.
+   *
+   * A reader deciding whether to keep reading has not reached the skills section. If the
+   * first fifteen lines establish nothing the advert asked for, the document is answering a
+   * question nobody got to.
+   * @param {Array} terms - Matched terms
+   * @param {string} text - The extracted text
+   * @param {number} [lines] - How much counts as the opening
+   * @returns {{present: string[], missing: string[]}} Required terms, split
+   */
+  static opening(terms, text, lines = 15) {
+    const head = String(text ?? '').split(/\r?\n/).filter((line) => line.trim()).slice(0, lines).join('\n');
+    const required = terms.filter((entry) => entry.required);
+    return {
+      present: required.filter((entry) => AdvertMatcher.appears(entry.term, head)).map((entry) => entry.term),
+      missing: required.filter((entry) => !AdvertMatcher.appears(entry.term, head)).map((entry) => entry.term)
     };
   }
 

--- a/core/AtsReport.js
+++ b/core/AtsReport.js
@@ -13,9 +13,10 @@ export class AtsReport {
   /**
    * @param {Object} score - An AtsScore result
    * @param {Array<{artefact: string, diff: Object}>} results - One entry per artefact
+   * @param {Object|null} [advert] - A matched advert, when one was given
    * @returns {string} Markdown
    */
-  static render(score, results) {
+  static render(score, results, advert = null) {
     return [
       '# Recoverability',
       '',
@@ -31,6 +32,8 @@ export class AtsReport {
       '',
       ...AtsReport.findings(results),
       '',
+      ...AtsReport.advertSection(advert),
+      '',
       '## How the number is composed',
       '',
       '| Band | Weight | What it measures |',
@@ -42,6 +45,51 @@ export class AtsReport {
       '',
       'Regenerate with `npm run audit:ats`.'
     ].join('\n');
+  }
+
+  /**
+   * The gap table, and the distinction that is worth more than the number.
+   *
+   * Two columns, because the two kinds of gap belong to different people. A term the CV
+   * writes that the artefact lost is a **layout defect** — the copy is right and the renderer
+   * is wrong. A term the CV never wrote is a **content gap**, and it is a human's decision.
+   *
+   * An absent term is stated and nothing more. The tool never suggests adding one: a term the
+   * experience does not support is a fabrication, and a helpful suggestion is how a fabricated
+   * CV gets built one line at a time.
+   */
+  static advertSection(advert) {
+    if (!advert) {
+      return ['## The advert', '', 'No advert was given, so nothing was matched against one.'];
+    }
+
+    const kind = (term) => {
+      if (term.evidence !== 'absent') return term.evidence === 'inProse' ? 'evidenced' : 'listed only';
+      return term.authored ? 'LAYOUT DEFECT — written, not recovered' : 'content gap — not claimed';
+    };
+
+    const lines = ['## The advert', ''];
+    if (advert.language) {
+      lines.push(`Written in \`${advert.language.language}\`.`, '');
+    }
+    lines.push('| Term | Required | Where the CV answers | Reading |', '|---|---|---|---|');
+    for (const term of advert.terms) {
+      lines.push(`| ${term.term} | ${term.required ? 'yes' : ''} | ${term.where || '—'} | ${kind(term)} |`);
+    }
+
+    const defects = advert.terms.filter((term) => term.evidence === 'absent' && term.authored);
+    const gaps = advert.terms.filter((term) => term.evidence === 'absent' && term.authored === false);
+    lines.push('',
+      `**${defects.length} layout defects** — the CV claims these and the artefact lost them. Fix the renderer, not the copy.`,
+      `**${gaps.length} content gaps** — the CV does not claim these. Whether any of them should be claimed is a decision for a person, and this tool does not make it.`);
+
+    if (advert.opening) {
+      lines.push('',
+        advert.opening.missing.length
+          ? `The opening fifteen lines establish ${advert.opening.present.length} of ${advert.opening.present.length + advert.opening.missing.length} required terms. A reader deciding whether to continue has not reached the skills section.`
+          : 'Every required term appears in the opening fifteen lines.');
+    }
+    return lines;
   }
 
   static unscoredNote(score) {

--- a/core/LetterExporter.js
+++ b/core/LetterExporter.js
@@ -1,0 +1,62 @@
+import { CoverLetter } from '../domain/CoverLetter.js';
+import { CvDocument } from '../domain/CvDocument.js';
+import { PageFormat } from '../domain/PageFormat.js';
+import { LayoutThemeRegistry } from '../adapters/LayoutThemeRegistry.js';
+import { PdfDesignSystem } from '../adapters/PdfDesignSystem.js';
+import { LetterLayout } from '../adapters/LetterLayout.js';
+
+/**
+ * The cover letter's half of the export path.
+ *
+ * Deliberately the same two-method shape as `PdfExporter` — `buildDocument` and `filename` —
+ * so `PdfGenerationService` drives both without knowing which it holds. A second service for
+ * a second document would have been a copy of the first with one word changed.
+ *
+ * It resolves the theme from the CV layout it accompanies, because the pair travels together:
+ * the letter is the first page a reader opens and the CV is the second, and two typefaces
+ * across those two pages read as two people.
+ */
+export class LetterExporter {
+  constructor(_renderer = null, i18n = null, dependencies = {}) {
+    this.i18n = i18n;
+    this.pageFormats = dependencies.pageFormats || new PageFormat();
+    this.themes = dependencies.themes || new LayoutThemeRegistry();
+    this.designSystem = dependencies.designSystem || new PdfDesignSystem();
+    this.layout = dependencies.layout || new LetterLayout();
+  }
+
+  /**
+   * The `-cover` in the name is load-bearing, not cosmetic — and it is `-cover` rather than
+   * `-letter` because the paper size LETTER already owns that word: a cover letter on LETTER
+   * paper would have been `…-letter-letter-color.pdf`, and every check that told the two
+   * apart would have been a regex nobody could read twice.
+   *
+   * `audit-ats` reads every PDF beside the CV and would parse this one as a résumé — a
+   * one-page letter has no headings, no chronology and no skills, so it would report a failed
+   * segmentation and trip two floors on a perfectly good letter. A false failure is worse
+   * than no check, because it teaches whoever sees it to ignore the exit code.
+   */
+  filename({ profile = 'general', locale = 'en', layout = 'spotlight', pageSize = 'A4', colorMode = 'color', variant = false } = {}) {
+    const suffix = variant ? `-${pageSize.toLowerCase()}-${colorMode}` : '';
+    return `giovanni-trovato-${profile}-${locale}-${layout}-cover${suffix}.pdf`;
+  }
+
+  /** True when a profile carries a letter at all. The published CV does not. */
+  static has(data) {
+    return Boolean(data && data.letter && Object.keys(data.letter).length);
+  }
+
+  buildDocument(data, options = {}) {
+    if (typeof options === 'string') options = { layout: options };
+    const { layout = 'spotlight', pageSize = 'A4', colorMode = 'color', locale = 'en' } = options;
+    const letter = new CoverLetter(data.letter);
+    const { identity } = new CvDocument(data);
+    const format = this.pageFormats.resolve(pageSize);
+    const theme = this.themes.resolve(layout, colorMode);
+    const t = (key) => this.i18n?.t(key) || key;
+
+    return this.layout.compose(letter, {
+      identity, format, theme, typography: this.designSystem.resolve(theme), t, locale
+    });
+  }
+}

--- a/docs/ATS_AUDIT.md
+++ b/docs/ATS_AUDIT.md
@@ -33,6 +33,10 @@ traces to a 2012 sales pitch with no published method; it is not repeated here.
 Nothing. Every field the document writes came back in its own slot.
 
 
+## The advert
+
+No advert was given, so nothing was matched against one.
+
 ## How the number is composed
 
 | Band | Weight | What it measures |

--- a/docs/ATS_AUDIT.md
+++ b/docs/ATS_AUDIT.md
@@ -59,4 +59,5 @@ Regenerate with `npm run audit:ats`.
 - `7cfad5afe25a` — generated/qa/giovanni-trovato-general-en-spotlight-letter-color.pdf, generated/qa/giovanni-trovato-general-en-spotlight-letter-monochrome.pdf
 - `0de521e52af0` — generated/qa/giovanni-trovato-general-en-technical-letter-color.pdf, generated/qa/giovanni-trovato-general-en-technical-letter-monochrome.pdf
 
+
 A layout-aware read of at least one artefact recovers a different number of roles. That is where a column is being serialised; reported, not scored.

--- a/domain/AdvertLexicon.js
+++ b/domain/AdvertLexicon.js
@@ -79,6 +79,19 @@ export const ADVERT = {
       'cosa richiediamo', 'competenze richieste']
   },
 
+  /**
+   * Headings that organise an advert without demanding or offering anything. Their own words
+   * are structure, not requirements: `Tech Stack` is not a technology.
+   */
+  structuralHeadings: {
+    en: ['role', 'the role', 'about the role', 'focus', 'responsibilities', 'outcomes',
+      'tech stack', 'our stack', 'how we work', 'interview process', 'the team', 'location'],
+    de: ['die rolle', 'aufgaben', 'schwerpunkte', 'technologien', 'unser stack',
+      'so arbeiten wir', 'bewerbungsprozess', 'das team', 'standort'],
+    it: ['il ruolo', 'mansioni', 'responsabilità', 'tecnologie', 'il nostro stack',
+      'come lavoriamo', 'processo di selezione', 'il team', 'sede']
+  },
+
   /** Headings under which an advert talks about itself. Terms below these are worth less. */
   offerHeadings: {
     en: ['we offer', 'what we offer', 'benefits', 'perks', 'about us', 'why join', 'our culture',
@@ -113,6 +126,7 @@ const STOPWORDS = set(ADVERT.stopwords);
 const BOILERPLATE = Object.values(ADVERT.boilerplate).flat().map(fold);
 const REQUIREMENT = Object.values(ADVERT.requirementHeadings).flat().map(fold);
 const OFFER = Object.values(ADVERT.offerHeadings).flat().map(fold);
+const STRUCTURAL = Object.values(ADVERT.structuralHeadings).flat().map(fold);
 
 const SYNONYM = new Map();
 for (const group of ADVERT.synonyms) {
@@ -147,6 +161,7 @@ export class AdvertLexicon {
     if (!folded || folded.length > 60) return null;
     if (REQUIREMENT.some((entry) => folded === entry || folded.startsWith(entry))) return 'required';
     if (OFFER.some((entry) => folded === entry || folded.startsWith(entry))) return 'offer';
+    if (STRUCTURAL.some((entry) => folded === entry)) return 'neutral';
     return null;
   }
 

--- a/domain/AdvertLexicon.js
+++ b/domain/AdvertLexicon.js
@@ -22,7 +22,13 @@ export const ADVERT = {
       'not', 'no', 'all', 'any', 'more', 'most', 'other', 'some', 'such', 'own', 'same', 'so',
       'than', 'too', 'very', 'just', 'also', 'about', 'into', 'over', 'across', 'while',
       'role', 'team', 'work', 'working', 'job', 'position', 'company', 'years', 'year',
-      'experience', 'strong', 'good', 'great', 'excellent', 'ability', 'skills', 'help'],
+      'experience', 'strong', 'good', 'great', 'excellent', 'ability', 'skills', 'help',
+      // Verbs and nouns every software advert uses and none of them means anything on their
+      // own: they outrank the technologies unless they are named here.
+      'build', 'building', 'maintain', 'maintaining', 'design', 'designing', 'create',
+      'develop', 'developing', 'support', 'provide', 'ensure', 'using', 'include',
+      'including', 'apps', 'application', 'applications', 'software', 'systems', 'product',
+      'products', 'high', 'solid', 'hands-on', 'closely', 'across'],
     de: ['der', 'die', 'das', 'den', 'dem', 'des', 'ein', 'eine', 'einen', 'einem', 'einer',
       'und', 'oder', 'aber', 'von', 'zu', 'in', 'im', 'an', 'am', 'auf', 'für', 'mit', 'aus',
       'bei', 'als', 'ist', 'sind', 'sein', 'wird', 'werden', 'kann', 'können', 'soll', 'sollen',
@@ -30,14 +36,17 @@ export const ADVERT = {
       'uns', 'es', 'dies', 'diese', 'dieser', 'wer', 'was', 'wie', 'wann', 'wo', 'nicht',
       'kein', 'alle', 'mehr', 'auch', 'sehr', 'nur', 'schon', 'über', 'durch', 'nach',
       'rolle', 'team', 'arbeit', 'stelle', 'position', 'unternehmen', 'jahre', 'jahren',
-      'erfahrung', 'kenntnisse', 'fähigkeiten'],
+      'erfahrung', 'kenntnisse', 'fähigkeiten', 'entwickeln', 'entwicklung', 'erstellen',
+      'pflegen', 'unterstützen', 'anwendung', 'anwendungen', 'software', 'systeme', 'produkt'],
     it: ['il', 'lo', 'la', 'i', 'gli', 'le', 'un', 'uno', 'una', 'e', 'ed', 'o', 'ma', 'di',
       'del', 'della', 'dei', 'delle', 'a', 'al', 'alla', 'ai', 'in', 'nel', 'nella', 'su',
       'per', 'con', 'da', 'dal', 'come', 'è', 'sono', 'essere', 'sarà', 'saranno', 'può',
       'possono', 'deve', 'devono', 'avere', 'ha', 'tu', 'tuo', 'tua', 'lei', 'noi', 'nostro',
       'nostra', 'ci', 'questo', 'questa', 'chi', 'che', 'cosa', 'come', 'quando', 'dove',
       'non', 'nessun', 'tutti', 'più', 'anche', 'molto', 'solo', 'già', 'ruolo', 'team',
-      'lavoro', 'posizione', 'azienda', 'anni', 'esperienza', 'competenze', 'capacità']
+      'lavoro', 'posizione', 'azienda', 'anni', 'esperienza', 'competenze', 'capacità',
+      'sviluppare', 'sviluppo', 'creare', 'mantenere', 'supportare', 'applicazione',
+      'applicazioni', 'software', 'sistemi', 'prodotto']
   },
 
   /**
@@ -144,6 +153,13 @@ export class AdvertLexicon {
   /** The canonical form of a term, when the table knows one. */
   static canonical(term) {
     return SYNONYM.get(fold(term)) || fold(term);
+  }
+
+  /** Every spelling the table knows for a term, its own included. */
+  static formsOf(term) {
+    const canonical = AdvertLexicon.canonical(term);
+    const group = ADVERT.synonyms.find((entry) => fold(entry[0]) === canonical);
+    return group ? group.map(fold) : [fold(term)];
   }
 
   /** Whether two terms mean the same thing through the table rather than by spelling. */

--- a/domain/AdvertLexicon.js
+++ b/domain/AdvertLexicon.js
@@ -1,0 +1,172 @@
+import { fold } from './fold.js';
+
+/**
+ * What a job advert says that is not about the job.
+ *
+ * The same shape as `SectionLexicon` and `MONTHS`: a map from purpose to per-language lists,
+ * so adding a language is adding entries and nothing else changes.
+ *
+ * The honest difference from the section lexicon, and it belongs in the module rather than in
+ * a ticket: **there is no catalogue to check coverage against.** An advert's vocabulary is not
+ * ours, so no test can discover the words we are missing. What a test can assert is the shape,
+ * and that a known advert in each language yields terms a person would agree with. Everything
+ * below is therefore a floor, not a guarantee, and the report says so.
+ */
+export const ADVERT = {
+  /** Words that carry no information about a role, however often they appear. */
+  stopwords: {
+    en: ['the', 'a', 'an', 'and', 'or', 'but', 'of', 'to', 'in', 'on', 'at', 'for', 'with',
+      'from', 'by', 'as', 'is', 'are', 'be', 'been', 'being', 'will', 'would', 'can', 'could',
+      'should', 'have', 'has', 'had', 'you', 'your', 'we', 'our', 'us', 'they', 'their', 'it',
+      'its', 'this', 'that', 'these', 'those', 'who', 'what', 'which', 'how', 'when', 'where',
+      'not', 'no', 'all', 'any', 'more', 'most', 'other', 'some', 'such', 'own', 'same', 'so',
+      'than', 'too', 'very', 'just', 'also', 'about', 'into', 'over', 'across', 'while',
+      'role', 'team', 'work', 'working', 'job', 'position', 'company', 'years', 'year',
+      'experience', 'strong', 'good', 'great', 'excellent', 'ability', 'skills', 'help'],
+    de: ['der', 'die', 'das', 'den', 'dem', 'des', 'ein', 'eine', 'einen', 'einem', 'einer',
+      'und', 'oder', 'aber', 'von', 'zu', 'in', 'im', 'an', 'am', 'auf', 'für', 'mit', 'aus',
+      'bei', 'als', 'ist', 'sind', 'sein', 'wird', 'werden', 'kann', 'können', 'soll', 'sollen',
+      'haben', 'hat', 'du', 'dein', 'deine', 'sie', 'ihr', 'ihre', 'wir', 'unser', 'unsere',
+      'uns', 'es', 'dies', 'diese', 'dieser', 'wer', 'was', 'wie', 'wann', 'wo', 'nicht',
+      'kein', 'alle', 'mehr', 'auch', 'sehr', 'nur', 'schon', 'über', 'durch', 'nach',
+      'rolle', 'team', 'arbeit', 'stelle', 'position', 'unternehmen', 'jahre', 'jahren',
+      'erfahrung', 'kenntnisse', 'fähigkeiten'],
+    it: ['il', 'lo', 'la', 'i', 'gli', 'le', 'un', 'uno', 'una', 'e', 'ed', 'o', 'ma', 'di',
+      'del', 'della', 'dei', 'delle', 'a', 'al', 'alla', 'ai', 'in', 'nel', 'nella', 'su',
+      'per', 'con', 'da', 'dal', 'come', 'è', 'sono', 'essere', 'sarà', 'saranno', 'può',
+      'possono', 'deve', 'devono', 'avere', 'ha', 'tu', 'tuo', 'tua', 'lei', 'noi', 'nostro',
+      'nostra', 'ci', 'questo', 'questa', 'chi', 'che', 'cosa', 'come', 'quando', 'dove',
+      'non', 'nessun', 'tutti', 'più', 'anche', 'molto', 'solo', 'già', 'ruolo', 'team',
+      'lavoro', 'posizione', 'azienda', 'anni', 'esperienza', 'competenze', 'capacità']
+  },
+
+  /**
+   * The furniture of a job posting: legal notices, benefits, gender markers, calls to apply.
+   * Ranked highly by frequency and worth nothing, which is why they are named rather than
+   * filtered by a threshold.
+   */
+  boilerplate: {
+    en: ['equal opportunity', 'equal opportunities', 'regardless of', 'we offer', 'what we offer',
+      'benefits', 'perks', 'apply now', 'send your cv', 'full time', 'full-time', 'part time',
+      'part-time', 'permanent', 'competitive salary', 'about us', 'join us', 'our mission',
+      'diverse', 'inclusive', 'flexible hours', 'remote friendly'],
+    de: ['m/w/d', 'w/m/d', 'm/w/x', 'gn', 'chancengleichheit', 'unabhängig von', 'wir bieten',
+      'was wir bieten', 'benefits', 'jetzt bewerben', 'bewerbung', 'vollzeit', 'teilzeit',
+      'unbefristet', 'befristet', 'über uns', 'unsere mission', 'deine aufgaben', 'ihre aufgaben',
+      'attraktive vergütung', 'flexible arbeitszeiten'],
+    it: ['l. 68/99', 'pari opportunità', 'indipendentemente da', 'offriamo', 'cosa offriamo',
+      'benefit', 'candidati ora', 'invia il tuo cv', 'tempo pieno', 'part time', 'indeterminato',
+      'determinato', 'chi siamo', 'la nostra missione', 'le tue mansioni', 'sede di lavoro',
+      'retribuzione commisurata', 'orario flessibile']
+  },
+
+  /** Headings under which an advert states what it will not compromise on. */
+  requirementHeadings: {
+    en: ['requirements', 'required', 'must have', 'essential', 'qualifications', 'you have',
+      'what you bring', 'who you are', 'ideal experiences', 'we are looking for'],
+    de: ['anforderungen', 'voraussetzungen', 'qualifikationen', 'ihr profil', 'dein profil',
+      'das bringen sie mit', 'das bringst du mit', 'wen wir suchen', 'must-have'],
+    it: ['requisiti', 'requisiti richiesti', 'qualifiche', 'il tuo profilo', 'chi cerchiamo',
+      'cosa richiediamo', 'competenze richieste']
+  },
+
+  /** Headings under which an advert talks about itself. Terms below these are worth less. */
+  offerHeadings: {
+    en: ['we offer', 'what we offer', 'benefits', 'perks', 'about us', 'why join', 'our culture',
+      'how we work'],
+    de: ['wir bieten', 'was wir bieten', 'benefits', 'über uns', 'unsere kultur', 'warum wir'],
+    it: ['offriamo', 'cosa offriamo', 'benefit', 'chi siamo', 'la nostra cultura', 'perché noi']
+  },
+
+  /**
+   * Hand-curated, and short on purpose.
+   *
+   * A general synonym engine, a stemmer or embeddings would each need a dependency, and each
+   * would make the matcher's mistakes harder to see. A match through this table is reported as
+   * `synonym`, never as `exact`, so a reader can tell which rung a term arrived on.
+   */
+  synonyms: [
+    ['mdm', 'mobile device management'],
+    ['ci/cd', 'continuous integration', 'continuous delivery', 'continuous deployment'],
+    ['ml', 'machine learning'],
+    ['ui', 'user interface'],
+    ['ux', 'user experience'],
+    ['qa', 'quality assurance'],
+    ['spm', 'swift package manager'],
+    ['tdd', 'test driven development', 'test-driven development'],
+    ['api', 'apis'],
+    ['ios', 'apple platform', 'apple platforms']
+  ]
+};
+
+const set = (group) => new Set(Object.values(group).flat().map(fold));
+const STOPWORDS = set(ADVERT.stopwords);
+const BOILERPLATE = Object.values(ADVERT.boilerplate).flat().map(fold);
+const REQUIREMENT = Object.values(ADVERT.requirementHeadings).flat().map(fold);
+const OFFER = Object.values(ADVERT.offerHeadings).flat().map(fold);
+
+const SYNONYM = new Map();
+for (const group of ADVERT.synonyms) {
+  const canonical = fold(group[0]);
+  for (const form of group) SYNONYM.set(fold(form), canonical);
+}
+
+export class AdvertLexicon {
+  /** Every language the lexicon knows, discovered rather than declared. */
+  static languages() {
+    return [...new Set(Object.keys(ADVERT.stopwords))].sort();
+  }
+
+  /** A word that carries no information about the role, in any supported language. */
+  static isStopword(word) {
+    return STOPWORDS.has(fold(word));
+  }
+
+  /** A phrase that belongs to the posting rather than to the job. */
+  static isBoilerplate(phrase) {
+    const folded = fold(phrase);
+    return BOILERPLATE.some((entry) => folded === entry || folded.includes(entry));
+  }
+
+  /**
+   * What a line is, when it is a heading: what the advert demands, or what it offers.
+   * @param {string} line - One line of the advert
+   * @returns {'required'|'offer'|null} Which kind of heading, if any
+   */
+  static headingKind(line) {
+    const folded = fold(line).replace(/[:*#•\-–—]/g, ' ').replace(/\s+/g, ' ').trim();
+    if (!folded || folded.length > 60) return null;
+    if (REQUIREMENT.some((entry) => folded === entry || folded.startsWith(entry))) return 'required';
+    if (OFFER.some((entry) => folded === entry || folded.startsWith(entry))) return 'offer';
+    return null;
+  }
+
+  /** The canonical form of a term, when the table knows one. */
+  static canonical(term) {
+    return SYNONYM.get(fold(term)) || fold(term);
+  }
+
+  /** Whether two terms mean the same thing through the table rather than by spelling. */
+  static areSynonyms(a, b) {
+    return fold(a) !== fold(b) && AdvertLexicon.canonical(a) === AdvertLexicon.canonical(b);
+  }
+
+  /**
+   * Which language an advert is written in, by how many of its words are that language's
+   * stopwords. Reported rather than acted on: a German advert against an English CV is a
+   * finding, not something to correct silently.
+   * @param {string} text - The advert
+   * @returns {{language: string, confidence: number}|null} The best guess
+   */
+  static languageOf(text) {
+    const words = fold(text).split(/[^a-z0-9äöüß']+/).filter(Boolean);
+    if (words.length < 20) return null;
+
+    const scores = Object.entries(ADVERT.stopwords).map(([language, list]) => {
+      const stops = new Set(list.map(fold));
+      return { language, confidence: words.filter((word) => stops.has(word)).length / words.length };
+    }).sort((a, b) => b.confidence - a.confidence);
+
+    return scores[0].confidence > 0.05 ? scores[0] : null;
+  }
+}

--- a/domain/CoverLetter.js
+++ b/domain/CoverLetter.js
@@ -1,0 +1,82 @@
+/**
+ * A cover letter, as the data writes it.
+ *
+ * The counterpart of `CvDocument`: framework-free, no I/O, and the single shape every output
+ * boundary consumes. It normalises a partial letter rather than trusting a complete one,
+ * because a letter is written once per application and the half-filled state is the normal
+ * one, not the exception.
+ *
+ * What it will not do is invent. A missing recipient is reported as missing, never replaced
+ * with a plausible name — `cv-composer` already carries that rule for copy, and the model
+ * enforces it in the only way a model can: by making the absence legible. `missing` exists so
+ * a caller can ask instead of guessing.
+ *
+ * It says **who** is addressed, never **how**. The wording of a salutation belongs to the
+ * catalogue, like every other user-visible string in this project; a domain object that wrote
+ * "Dear Hiring Team" would be a German letter's bug waiting to happen.
+ */
+export class CoverLetter {
+  constructor(data = {}) {
+    const recipient = data.recipient || {};
+    this.recipient = {
+      name: text(recipient.name),
+      role: text(recipient.role),
+      company: text(recipient.company),
+      address: lines(recipient.address)
+    };
+    /** As the data wrote it. Formatting belongs to `Intl` at the boundary, not here. */
+    this.date = text(data.date);
+    /** The advert's own reference, when it has one. A recruiter searches by it. */
+    this.reference = text(data.reference);
+    this.subject = text(data.subject);
+    this.opening = text(data.opening);
+    this.body = lines(data.body);
+    this.closing = text(data.closing);
+    this.signature = text(data.signature);
+    this.attachments = lines(data.attachments);
+  }
+
+  /** Who to address, or null. The wording is the catalogue's business. */
+  get addressee() {
+    return this.recipient.name || null;
+  }
+
+  /**
+   * What the letter still needs.
+   *
+   * Named rather than filled: a letter addressed to nobody at a company nobody named is worse
+   * than no letter, and the only honest thing a model can do about it is say so.
+   * @returns {string[]} Field names, in the order a writer would fill them
+   */
+  get missing() {
+    const required = [
+      ['recipient.company', this.recipient.company],
+      ['subject', this.subject],
+      ['opening', this.opening],
+      ['body', this.body.length ? 'yes' : ''],
+      ['signature', this.signature]
+    ];
+    return required.filter(([, value]) => !value).map(([name]) => name);
+  }
+
+  /** Enough to put in front of an employer. */
+  get isComplete() {
+    return this.missing.length === 0;
+  }
+
+  /** Every word the letter says, for an audit that asks what survived extraction. */
+  get prose() {
+    return [this.subject, this.opening, ...this.body, this.closing].filter(Boolean).join('\n');
+  }
+}
+
+function text(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+/** A block that may arrive as one string or as the paragraphs it already is. */
+function lines(value) {
+  if (Array.isArray(value)) return value.map(text).filter(Boolean);
+  const single = text(value);
+  return single ? single.split(/\n{2,}/).map(text).filter(Boolean) : [];
+}

--- a/locales/de/cv.json
+++ b/locales/de/cv.json
@@ -8,6 +8,19 @@
     "certifications": "Zertifizierungen",
     "interests": "Interessen"
   },
-  "experience": { "at": "bei" },
-  "contacts": { "email": "E-Mail", "phone": "Telefon", "portfolio": "Portfolio" }
+  "experience": {
+    "at": "bei"
+  },
+  "contacts": {
+    "email": "E-Mail",
+    "phone": "Telefon",
+    "portfolio": "Portfolio"
+  },
+  "letter": {
+    "subject": "Bewerbung",
+    "salutationNamed": "Sehr geehrte(r)",
+    "salutationAnonymous": "Sehr geehrte Damen und Herren",
+    "closing": "Mit freundlichen Grüßen",
+    "attachments": "Anlagen"
+  }
 }

--- a/locales/en/cv.json
+++ b/locales/en/cv.json
@@ -8,6 +8,19 @@
     "certifications": "Certifications",
     "interests": "Interests"
   },
-  "experience": { "at": "at" },
-  "contacts": { "email": "Email", "phone": "Phone", "portfolio": "Portfolio" }
+  "experience": {
+    "at": "at"
+  },
+  "contacts": {
+    "email": "Email",
+    "phone": "Phone",
+    "portfolio": "Portfolio"
+  },
+  "letter": {
+    "subject": "Application",
+    "salutationNamed": "Dear",
+    "salutationAnonymous": "Dear Hiring Team",
+    "closing": "Kind regards,",
+    "attachments": "Enclosed"
+  }
 }

--- a/scripts/audit-ats.mjs
+++ b/scripts/audit-ats.mjs
@@ -6,6 +6,7 @@ import { AtsTextParser } from '../core/AtsTextParser.js';
 import { RecoveryDiff } from '../core/RecoveryDiff.js';
 import { AtsScore } from '../core/AtsScore.js';
 import { AtsReport } from '../core/AtsReport.js';
+import { AdvertMatcher } from '../core/AdvertMatcher.js';
 import { GenerationTarget } from '../core/GenerationTarget.js';
 
 /**
@@ -38,6 +39,19 @@ try {
   cannotCheck(`cannot read ${target.dataPath}`, error.message);
 }
 
+// An advert that cannot be read is not the same as no advert: the first is a mistake to
+// report, the second a deliberate run without one. Silently treating them alike would let a
+// typo in a path look like a decision.
+const advertPath = process.argv.slice(2).find((argument) => argument.startsWith('--advert='))?.slice(9);
+let advertText = null;
+if (advertPath) {
+  try {
+    advertText = await readFile(advertPath, 'utf8');
+  } catch (error) {
+    cannotCheck(`cannot read the advert at ${advertPath}`, error.message);
+  }
+}
+
 try {
   execFileSync('pdftotext', ['-v'], { stdio: 'ignore' });
 } catch {
@@ -59,6 +73,7 @@ if (!files.length) {
 
 const results = [];
 const seen = new Map();
+let advert = null;
 for (const { artefact, path } of files) {
   const text = execFileSync('pdftotext', [path, '-'], { encoding: 'utf8' });
   const fingerprint = createHash('sha256').update(text).digest('hex');
@@ -74,6 +89,14 @@ for (const { artefact, path } of files) {
 
   const recovered = AtsTextParser.parse(text);
   const diff = RecoveryDiff.diff(document, recovered);
+  if (advertText && !advert) {
+    const extracted = AdvertMatcher.extractTerms(advertText);
+    advert = {
+      ...AdvertMatcher.match(extracted.terms, recovered, document),
+      language: extracted.language
+    };
+    advert.opening = AdvertMatcher.opening(advert.terms, text);
+  }
 
   // The same file read the way a better extractor reads it. Where the two disagree is where
   // a column was serialised — reported, not scored, until a fixture pins down what a bad
@@ -86,7 +109,7 @@ for (const { artefact, path } of files) {
 
 // The worst artefact, not the first. You send one of these, and the headline should be the
 // one you risk rather than the one that happens to be alphabetically first.
-const scores = results.map((entry) => AtsScore.compose(entry.diff));
+const scores = results.map((entry) => AtsScore.compose(entry.diff, advert));
 const score = scores.reduce((worst, candidate) => (candidate.points < worst.points ? candidate : worst));
 
 // The floors: not the score, which never gates anything, but the four failures that mean the
@@ -99,7 +122,7 @@ const floors = results.flatMap(({ artefact, diff }) => [
 ].filter(Boolean));
 
 const report = [
-  AtsReport.render(score, results),
+  AtsReport.render(score, results, advert),
   '',
   '## Distinct text streams',
   '',

--- a/scripts/audit-ats.mjs
+++ b/scripts/audit-ats.mjs
@@ -33,8 +33,10 @@ function cannotCheck(reason, hint) {
 }
 
 let document;
+let authored;
 try {
-  document = new CvDocument(JSON.parse(await readFile(new URL(target.dataPath, projectRoot))));
+  authored = JSON.parse(await readFile(new URL(target.dataPath, projectRoot)));
+  document = new CvDocument(authored);
 } catch (error) {
   cannotCheck(`cannot read ${target.dataPath}`, error.message);
 }
@@ -64,18 +66,43 @@ for (const directory of directories) {
   const url = new URL(`${directory}/`, projectRoot);
   const entries = await readdir(url).catch(() => []);
   files.push(...entries.filter((name) => name.endsWith('.pdf')).sort()
-    .map((name) => ({ artefact: `${directory}/${name}`, path: new URL(name, url).pathname })));
+    .map((name) => ({
+      artefact: `${directory}/${name}`,
+      path: new URL(name, url).pathname,
+      // A cover letter is not a CV and must not be parsed as one: it has no headings, no
+      // chronology and no skills, so this audit would report a failed segmentation and trip
+      // two floors on a perfectly good letter. A false failure is worse than no check — it
+      // teaches whoever sees it to ignore the exit code.
+      isCover: /-cover(-|\.)/.test(name)
+    })));
 }
 
-if (!files.length) {
+if (!files.filter((file) => !file.isCover).length) {
   cannotCheck(`no PDFs under ${target.outDir}`, 'Run `npm run build:pdf` first, with the same --profile.');
 }
 
 const results = [];
+const letters = [];
 const seen = new Map();
 let advert = null;
-for (const { artefact, path } of files) {
+for (const { artefact, path, isCover } of files) {
   const text = execFileSync('pdftotext', [path, '-'], { encoding: 'utf8' });
+  if (isCover) {
+    // The letter's own question, and the only one worth asking of it here: does the reader
+    // it names survive extraction?
+    // Read from the authored JSON, not from CvDocument: that model is the CV's and does not
+    // carry a letter, so `document.letter` was always undefined and `[].every()` was always
+    // true — a check that could not fail, found by breaking the thing it was meant to catch.
+    const wanted = [authored.letter?.recipient?.company, authored.letter?.subject].filter(Boolean);
+    letters.push({
+      artefact,
+      wanted,
+      // Nothing to compare against is not a pass. A cover letter beside a profile that
+      // carries none is a mismatch worth saying out loud.
+      recovered: wanted.length ? wanted.every((term) => text.includes(term)) : null
+    });
+    continue;
+  }
   const fingerprint = createHash('sha256').update(text).digest('hex');
 
   // The colour and monochrome variants are textually identical and A4 and LETTER are not,
@@ -114,12 +141,16 @@ const score = scores.reduce((worst, candidate) => (candidate.points < worst.poin
 
 // The floors: not the score, which never gates anything, but the four failures that mean the
 // parsed record is unusable however good the rest looks.
-const floors = results.flatMap(({ artefact, diff }) => [
+const floors = letters.filter((entry) => entry.recovered !== true)
+  .map((entry) => (entry.recovered === null
+    ? `${entry.artefact}: a cover letter was generated but the profile carries no letter to check it against`
+    : `${entry.artefact}: the letter's recipient or subject did not survive extraction`))
+  .concat(results.flatMap(({ artefact, diff }) => [
   diff.segmentation !== 'ok' && `${artefact}: the document did not segment`,
   diff.identity.email === 'lost' && `${artefact}: the email address was not recovered`,
   diff.experience.some((role) => !role.tripleAdjacent) && `${artefact}: a role lost its title, employer or period`,
   !diff.roleOrderMonotonic && `${artefact}: the chronology does not run one way`
-].filter(Boolean));
+].filter(Boolean)));
 
 const report = [
   AtsReport.render(score, results, advert),
@@ -130,6 +161,10 @@ const report = [
   '',
   ...[...seen.entries()].map(([fingerprint, group]) =>
     `- \`${fingerprint.slice(0, 12)}\` — ${group.join(', ')}`),
+  '',
+  ...(letters.length ? ['', '## Cover letters', '',
+    ...letters.map((entry) => `- ${entry.artefact} — recipient and subject ${entry.recovered === null ? 'COULD NOT BE CHECKED' : (entry.recovered ? 'survive' : 'DO NOT survive')} extraction`)]
+    : []),
   '',
   results.some((entry) => entry.divergence)
     ? 'A layout-aware read of at least one artefact recovers a different number of roles. That is where a column is being serialised; reported, not scored.'

--- a/scripts/audit-pdfs.mjs
+++ b/scripts/audit-pdfs.mjs
@@ -4,6 +4,7 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { GenerationTarget } from '../core/GenerationTarget.js';
 import { readableAddress } from '../domain/ReadableUrl.js';
+import { CoverLetter } from '../domain/CoverLetter.js';
 
 const projectRoot = new URL('../', import.meta.url);
 // The expectations come from the CV under test, not from the published one. Auditing a
@@ -119,6 +120,13 @@ function highlightsIntact(collapsed) {
   });
 }
 
+// A cover letter is a different document and has to be asked different questions: it has no
+// chronology, no skills and no second page, so every structural check written for a CV would
+// fail on a perfectly good one. The `-letter` in the name is the signal, which is why
+// LetterExporter puts it there.
+const isCoverLetter = (filename) => /-cover(-|\.)/.test(filename);
+const letter = profile.letter ? new CoverLetter(profile.letter) : null;
+
 for (const filename of pdfFiles) {
   const path = new URL(filename, qaUrl).pathname;
   const info = execFileSync('pdfinfo', [path], { encoding: 'utf8' });
@@ -134,7 +142,18 @@ for (const filename of pdfFiles) {
   // grayscale check never ran and every variant reported a guarantee nobody verified.
   const isMonochrome = filename.includes('-monochrome');
   const order = [profile.name, profile.title, labels.experience].map((term) => extracted.indexOf(term));
-  const checks = {
+  const checks = isCoverLetter(filename) ? {
+    format: sizeOk,
+    // One page. A cover letter that runs onto a second is a letter nobody finishes.
+    pages: pages === 1,
+    // The three things that make it a letter rather than a page of prose. A letter whose
+    // company name does not extract is addressed to nobody.
+    content: [letter?.recipient.company, letter?.subject, letter?.signature]
+      .filter(Boolean).every((term) => extracted.includes(term)),
+    textOnly: imageList.trim().split('\n').length <= 2,
+    monochromeMode: !isMonochrome || await isGrayscale(path),
+    canonicalCompounds: !brokenForms.some(({ broken }) => broken.test(extracted))
+  } : {
     format: sizeOk,
     pages: pages > 0 && pages <= 2,
     content: mustHave.every((term) => extracted.includes(term)),

--- a/scripts/generate-pdfs.mjs
+++ b/scripts/generate-pdfs.mjs
@@ -6,6 +6,7 @@ import { PdfGenerationService } from '../core/PdfGenerationService.js';
 import { PdfMakeRenderer } from '../adapters/PdfMakeRenderer.js';
 import { NodeDirectoryWriter } from '../adapters/NodeDirectoryWriter.js';
 import { GenerationTarget } from '../core/GenerationTarget.js';
+import { LetterExporter } from '../core/LetterExporter.js';
 
 const projectRoot = new URL('../', import.meta.url);
 const target = GenerationTarget.fromArguments(process.argv.slice(2));
@@ -45,6 +46,7 @@ pdfMake.fonts = {
   }
 };
 const composer = new PdfExporter(null, i18n);
+const letterComposer = new LetterExporter(null, i18n);
 const renderer = new PdfMakeRenderer(pdfMake);
 const releaseService = new PdfGenerationService({
   composer,
@@ -56,6 +58,15 @@ const qaService = new PdfGenerationService({
   renderer,
   writer: new NodeDirectoryWriter(new URL(`${target.qaDir}/`, projectRoot))
 });
+// The letter rides the same service: two documents, one pipeline, because a second copy of
+// generate-and-write would be the first with one word changed.
+const letterRelease = new PdfGenerationService({
+  composer: letterComposer, renderer, writer: new NodeDirectoryWriter(new URL(`${target.outDir}/`, projectRoot))
+});
+const letterQa = new PdfGenerationService({
+  composer: letterComposer, renderer, writer: new NodeDirectoryWriter(new URL(`${target.qaDir}/`, projectRoot))
+});
+const hasLetter = LetterExporter.has(data);
 
 // What the page is allowed to offer. The naming rule can name a file for any combination;
 // only this loop knows which ones exist, so it says so rather than leaving the page to guess.
@@ -65,10 +76,18 @@ for (const layout of layouts) {
   const result = await releaseService.generate(data, { profile, locale, layout });
   released.push(result.filename);
   console.log(`${target.outDir}/${result.filename}`);
+  if (hasLetter) {
+    const letter = await letterRelease.generate(data, { profile, locale, layout });
+    console.log(`${target.outDir}/${letter.filename}`);
+  }
   for (const pageSize of ['A4', 'LETTER']) {
     for (const colorMode of ['color', 'monochrome']) {
       const variant = await qaService.generate(data, { profile, locale, layout, pageSize, colorMode, variant: true });
       console.log(`${target.qaDir}/${variant.filename}`);
+      if (hasLetter) {
+        const letter = await letterQa.generate(data, { profile, locale, layout, pageSize, colorMode, variant: true });
+        console.log(`${target.qaDir}/${letter.filename}`);
+      }
     }
   }
 }

--- a/tests/AdvertGaps.test.js
+++ b/tests/AdvertGaps.test.js
@@ -1,0 +1,95 @@
+/**
+ * @jest-environment node
+ *
+ * The distinction this whole tool exists for: a term the CV writes and the artefact lost is a
+ * layout defect; a term the CV never wrote is a content gap. They belong to different people.
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { CvDocument } from '../domain/CvDocument.js';
+import { AtsTextParser } from '../core/AtsTextParser.js';
+import { AdvertMatcher } from '../core/AdvertMatcher.js';
+import { AtsReport } from '../core/AtsReport.js';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const document = new CvDocument(JSON.parse(readFileSync(`${root}profiles/general/en.json`, 'utf8')));
+const text = readFileSync(`${root}tests/fixtures/ats/clean-english.txt`, 'utf8');
+const recovered = AtsTextParser.parse(text);
+
+const advert = `
+Requirements
+Swift and SwiftUI for the client.
+Experience with Kotlin and Jetpack Compose.
+Exposure to CoreML and TensorFlow Lite.
+`;
+
+const matched = (cv = recovered) => {
+  const { terms, language } = AdvertMatcher.extractTerms(advert);
+  return { ...AdvertMatcher.match(terms, cv, document), language };
+};
+const term = (name, result) => result.terms.find((entry) => entry.term.toLowerCase() === name.toLowerCase());
+
+describe('a gap has two possible causes and they are told apart', () => {
+  test('a term the CV writes and the artefact keeps is not a gap at all', () => {
+    const swift = term('Swift', matched());
+
+    expect(swift.evidence).toBe('inProse');
+    expect(swift.authored).toBe(true);
+  });
+
+  // The CV writes Kotlin and Jetpack Compose in its skills; the artefact keeps them, so this
+  // is `listed only` rather than a defect. The layout-defect case is the one below.
+  test('a term the CV writes but the artefact lost is a layout defect', () => {
+    // A parser that saw only the masthead: the skills section never arrived.
+    const shredded = AtsTextParser.parse([
+      'Giovanni Trovato', 'Senior iOS Engineer / Mobile Platform Owner', '',
+      'Professional Experience', '', 'Mobile Software Engineer',
+      'Cortado Mobile Solutions · Berlin', 'August 2018 – Present', '',
+      'Education', '', 'M.Sc.', 'Pisa · 2015'
+    ].join('\n'));
+    const kotlin = term('Kotlin', matched(shredded));
+
+    expect(kotlin.evidence).toBe('absent');
+    // Written in the profile, missing from the artefact — the renderer is wrong, not the copy.
+    expect(kotlin.authored).toBe(true);
+  });
+
+  test('a term the CV never wrote is a content gap', () => {
+    const coreml = term('CoreML', matched());
+
+    expect(coreml.evidence).toBe('absent');
+    expect(coreml.authored).toBe(false);
+  });
+});
+
+describe('the report separates them, and stops there', () => {
+  const result = matched();
+  const markdown = AtsReport.advertSection({ ...result, opening: AdvertMatcher.opening(result.terms, text) }).join('\n');
+
+  test('each reading is named', () => {
+    expect(markdown).toContain('content gap — not claimed');
+    expect(markdown).toMatch(/\*\*\d+ layout defects\*\*/);
+    expect(markdown).toMatch(/\*\*\d+ content gaps\*\*/);
+  });
+
+  test('a layout defect points at the renderer, a content gap at a person', () => {
+    expect(markdown).toMatch(/Fix the renderer, not the copy/);
+    expect(markdown).toMatch(/decision for a person, and this tool does not make it/);
+  });
+
+  // The boundary between tailoring a CV and fabricating one. A helpful suggestion is how a
+  // fabricated CV gets built one line at a time.
+  test('it never suggests adding a term the CV does not claim', () => {
+    expect(markdown).not.toMatch(/\b(add|consider adding|you should|recommend|suggest|include this)\b/i);
+  });
+
+  test('the opening is measured, because a reader deciding whether to continue has not reached the skills', () => {
+    expect(markdown).toMatch(/opening fifteen lines|Every required term appears in the opening/);
+  });
+});
+
+describe('with no advert', () => {
+  test('the section says so rather than being empty', () => {
+    expect(AtsReport.advertSection(null).join('\n')).toMatch(/No advert was given/);
+  });
+});

--- a/tests/AdvertLexicon.test.js
+++ b/tests/AdvertLexicon.test.js
@@ -1,0 +1,102 @@
+import { ADVERT, AdvertLexicon } from '../domain/AdvertLexicon.js';
+
+describe('the lexicon is multilingual by construction', () => {
+  // The same shape as SectionLexicon and MONTHS: a language is added by adding entries.
+  test('every group knows the same languages', () => {
+    const languages = AdvertLexicon.languages();
+
+    expect(languages).toEqual(['de', 'en', 'it']);
+    for (const group of ['stopwords', 'boilerplate', 'requirementHeadings', 'offerHeadings']) {
+      expect(Object.keys(ADVERT[group]).sort()).toEqual(languages);
+    }
+  });
+
+  test('a stopword in any language is a stopword', () => {
+    for (const word of ['the', 'with', 'der', 'für', 'della', 'anche']) {
+      expect(AdvertLexicon.isStopword(word)).toBe(true);
+    }
+  });
+
+  // The words that would otherwise dominate any frequency ranking, and mean nothing.
+  test('a technical term is never a stopword', () => {
+    for (const word of ['Swift', 'SwiftUI', 'CoreML', 'Kotlin', 'MDM', 'TestFlight']) {
+      expect(AdvertLexicon.isStopword(word)).toBe(false);
+    }
+  });
+});
+
+describe('the furniture of a posting', () => {
+  test.each([
+    'm/w/d', 'Vollzeit', 'Wir bieten', 'unbefristet',
+    'equal opportunity', 'What we offer', 'apply now',
+    'pari opportunità', 'tempo pieno'
+  ])('%s is boilerplate', (phrase) => {
+    expect(AdvertLexicon.isBoilerplate(phrase)).toBe(true);
+  });
+
+  test('the work itself is not boilerplate', () => {
+    for (const phrase of ['Build and maintain iOS applications using Swift and SwiftUI',
+      'Optimize performance, memory usage, and battery efficiency']) {
+      expect(AdvertLexicon.isBoilerplate(phrase)).toBe(false);
+    }
+  });
+});
+
+describe('what the advert demands, and what it is selling', () => {
+  test.each([
+    ['Requirements', 'required'],
+    ['Ideal Experiences', 'required'],
+    ['Anforderungen', 'required'],
+    ['Ihr Profil:', 'required'],
+    ['Il tuo profilo', 'required'],
+    ['We offer', 'offer'],
+    ['Wir bieten', 'offer'],
+    ['Benefits', 'offer']
+  ])('%s is a %s heading', (line, kind) => {
+    expect(AdvertLexicon.headingKind(line)).toBe(kind);
+  });
+
+  test('a sentence is not a heading', () => {
+    for (const line of [
+      'You will build a production-grade iOS application where AI interactions are central.',
+      '3+ years of iOS development experience using Swift.'
+    ]) {
+      expect(AdvertLexicon.headingKind(line)).toBeNull();
+    }
+  });
+});
+
+describe('synonyms are curated, and say so', () => {
+  test.each([
+    ['MDM', 'Mobile Device Management'],
+    ['CI/CD', 'Continuous Integration'],
+    ['TDD', 'test-driven development'],
+    ['SPM', 'Swift Package Manager']
+  ])('%s and %s are the same thing', (a, b) => {
+    expect(AdvertLexicon.areSynonyms(a, b)).toBe(true);
+  });
+
+  // Nothing is inferred. Two terms that merely look related are not synonyms, because a
+  // general engine would need a dependency and would hide its own mistakes.
+  test('nothing is a synonym by resemblance', () => {
+    expect(AdvertLexicon.areSynonyms('Swift', 'SwiftUI')).toBe(false);
+    expect(AdvertLexicon.areSynonyms('Android', 'iOS')).toBe(false);
+    expect(AdvertLexicon.areSynonyms('Swift', 'Swift')).toBe(false);
+  });
+});
+
+describe('the language of the advert', () => {
+  // Reported, never corrected. A German advert against an English CV is a finding.
+  test.each([
+    ['en', 'We are looking for an engineer who will build and maintain the iOS application with Swift and SwiftUI, and who can work with the team on the design of the interface and on the quality of the code we ship to our users.'],
+    ['de', 'Wir suchen einen Entwickler, der die iOS Anwendung mit Swift und SwiftUI baut und pflegt, und der mit dem Team an der Gestaltung der Oberfläche und an der Qualität des Codes arbeitet, den wir an unsere Nutzer ausliefern.'],
+    ['it', 'Cerchiamo uno sviluppatore che costruisca e mantenga l applicazione iOS con Swift e SwiftUI, e che lavori con il team sulla progettazione della interfaccia e sulla qualità del codice che rilasciamo ai nostri utenti.']
+  ])('%s is recognised', (language, text) => {
+    expect(AdvertLexicon.languageOf(text).language).toBe(language);
+  });
+
+  test('too little text is no answer rather than a guess', () => {
+    expect(AdvertLexicon.languageOf('Senior iOS Engineer')).toBeNull();
+    expect(AdvertLexicon.languageOf('')).toBeNull();
+  });
+});

--- a/tests/AdvertMatcher.test.js
+++ b/tests/AdvertMatcher.test.js
@@ -1,0 +1,129 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { AtsTextParser } from '../core/AtsTextParser.js';
+import { AdvertMatcher } from '../core/AdvertMatcher.js';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const recovered = AtsTextParser.parse(
+  readFileSync(`${root}tests/fixtures/ats/clean-english.txt`, 'utf8')
+);
+
+const advert = `
+Role
+As an iOS Software Engineer you own the iOS client experience.
+
+Focus
+Build and maintain iOS applications using Swift and SwiftUI.
+Integrate AI-powered features through backend APIs.
+Optimize performance, memory usage, and battery efficiency.
+
+Ideal Experiences
+3+ years of iOS development experience using Swift.
+Hands-on experience integrating AI-powered features into mobile apps.
+Strong understanding of async/await, concurrency, and background tasks.
+Exposure to CoreML or light on-device ML.
+Familiarity with feature flags or remote configuration systems.
+
+We offer
+A competitive salary, flexible hours and a diverse, inclusive team.
+Free fruit and a yearly learning budget.
+`;
+
+const extract = (limit = 16) => AdvertMatcher.extractTerms(advert, limit);
+const evidenceFor = (term, terms) => terms.find((entry) => entry.term.toLowerCase() === term.toLowerCase());
+
+describe('what the advert asks for', () => {
+  const { terms } = extract();
+
+  test('the technologies survive tokenising', () => {
+    const named = terms.map((entry) => entry.term.toLowerCase());
+
+    expect(named).toContain('swiftui');
+    expect(named).toContain('coreml');
+    expect(named).toContain('async/await');
+  });
+
+  // Requirements sit under their own heading, and the lexicon knows which headings those are.
+  test('a term under a requirements heading is marked required', () => {
+    expect(evidenceFor('CoreML', terms).required).toBe(true);
+    expect(evidenceFor('async/await', terms).required).toBe(true);
+  });
+
+  test('the benefits section is not the job', () => {
+    const named = terms.map((entry) => entry.term.toLowerCase());
+
+    for (const noise of ['competitive salary', 'flexible hours', 'free fruit', 'learning budget']) {
+      expect(named).not.toContain(noise);
+    }
+  });
+
+  // Sliding a window over one sentence produces six phrasings of one requirement. Kept as
+  // they are, they crowd out every other term in the advert — which is what happened the
+  // first time this ran against a real one.
+  test('one idea appears once, not once per window', () => {
+    const named = terms.map((entry) => entry.term.toLowerCase());
+    const family = named.filter((term) => term.includes('ai-powered'));
+
+    expect(family).toHaveLength(1);
+  });
+
+  test('an empty verb never outranks a technology', () => {
+    const named = terms.map((entry) => entry.term.toLowerCase());
+
+    for (const empty of ['build', 'maintain', 'using', 'applications', 'experience']) {
+      expect(named).not.toContain(empty);
+    }
+  });
+});
+
+describe('where the CV answers', () => {
+  const { terms } = extract();
+  const matched = AdvertMatcher.match(terms, recovered).terms;
+  const evidence = (term) => evidenceFor(term, matched)?.evidence;
+
+  // The distinction the whole thing exists for. A term in the prose of a role is a claim with
+  // a date and an employer attached; the same term in a list is a word.
+  test('prose beats a list', () => {
+    expect(evidence('Swift')).toBe('inProse');
+    expect(evidence('SwiftUI')).toBe('inSkillsOnly');
+  });
+
+  test('a term the CV does not claim is absent, and stays absent', () => {
+    expect(evidence('CoreML')).toBe('absent');
+    expect(evidence('async/await')).toBe('absent');
+  });
+
+  test('an answer names where it was found', () => {
+    expect(evidenceFor('Swift', matched).where).toBe('Cortado Mobile Solutions');
+    expect(evidenceFor('SwiftUI', matched).where).toBe('the skills list');
+    expect(evidenceFor('CoreML', matched).where).toBeNull();
+  });
+});
+
+describe('what counts as a mention', () => {
+  // `AI` inside `maintain` is not a mention of artificial intelligence, and a matcher that
+  // counts it reports a fit the CV does not have.
+  test('a term inside a longer word is not a mention', () => {
+    expect(AdvertMatcher.appears('AI', 'we maintain the sailing app')).toBeNull();
+    expect(AdvertMatcher.appears('AI', 'the AI features shipped')).toBe('exact');
+  });
+
+  test('a curated synonym is reported as one, never as an exact match', () => {
+    expect(AdvertMatcher.appears('MDM', 'owned the Mobile Device Management client')).toBe('synonym');
+    expect(AdvertMatcher.appears('MDM', 'owned the MDM client')).toBe('exact');
+  });
+
+  test('nothing matches by resemblance', () => {
+    expect(AdvertMatcher.appears('SwiftUI', 'built it in Swift')).toBeNull();
+    expect(AdvertMatcher.appears('CoreML', 'Clean Architecture, MVVM')).toBeNull();
+  });
+});
+
+describe('the language of the advert', () => {
+  test('it is reported, so a mismatch with the CV is visible', () => {
+    expect(extract().language.language).toBe('en');
+  });
+});

--- a/tests/CoverLetter.test.js
+++ b/tests/CoverLetter.test.js
@@ -1,0 +1,85 @@
+import { CoverLetter } from '../domain/CoverLetter.js';
+
+const complete = {
+  recipient: { name: 'Anna Weber', role: 'Talent Lead', company: 'ActAI', address: ['Chausseestraße 1', '10115 Berlin'] },
+  date: '2026-09-09',
+  reference: 'REQ-1042',
+  subject: 'Application for iOS Software Engineer',
+  opening: 'I am writing about the iOS Software Engineer position.',
+  body: ['Six years owning an enterprise MDM client.', 'Swift 6 concurrency and iOS 26 migrations.'],
+  closing: 'I would welcome the chance to talk.',
+  signature: 'Giovanni Trovato',
+  attachments: ['Curriculum vitae']
+};
+
+describe('a complete letter', () => {
+  const letter = new CoverLetter(complete);
+
+  test('keeps what it was given', () => {
+    expect(letter.recipient.company).toBe('ActAI');
+    expect(letter.recipient.address).toEqual(['Chausseestraße 1', '10115 Berlin']);
+    expect(letter.body).toHaveLength(2);
+    expect(letter.reference).toBe('REQ-1042');
+  });
+
+  test('is complete, and says so', () => {
+    expect(letter.isComplete).toBe(true);
+    expect(letter.missing).toEqual([]);
+  });
+
+  test('offers its prose to whatever has to check what survived', () => {
+    expect(letter.prose).toContain('Application for iOS Software Engineer');
+    expect(letter.prose).toContain('Swift 6 concurrency');
+  });
+});
+
+describe('a partial letter, which is the normal state', () => {
+  // A letter is written once per application, so half-filled is the ordinary case rather than
+  // the exception, and nothing here may crash on it.
+  test('an empty letter is an empty letter, not a pile of undefined', () => {
+    const letter = new CoverLetter();
+
+    expect(letter.recipient.name).toBe('');
+    expect(letter.body).toEqual([]);
+    expect(letter.attachments).toEqual([]);
+    expect(letter.prose).toBe('');
+  });
+
+  test('it names what it still needs, in the order a writer would fill them', () => {
+    const letter = new CoverLetter({ recipient: { company: 'ActAI' }, subject: 'x' });
+
+    expect(letter.isComplete).toBe(false);
+    expect(letter.missing).toEqual(['opening', 'body', 'signature']);
+  });
+
+  // The rule that matters: nothing is invented. A letter addressed to nobody at a company
+  // nobody named is worse than no letter, and the only honest thing to do is say so.
+  test('a missing recipient is reported, never replaced', () => {
+    const letter = new CoverLetter({ ...complete, recipient: { company: 'ActAI' } });
+
+    expect(letter.addressee).toBeNull();
+    expect(letter.recipient.name).toBe('');
+    expect(letter.isComplete).toBe(true);
+  });
+
+  test('it says who is addressed and never how', () => {
+    const source = JSON.stringify(new CoverLetter(complete));
+
+    for (const wording of ['Dear', 'Sehr geehrte', 'Gentile', 'Hiring Team']) {
+      expect(source).not.toContain(wording);
+    }
+  });
+});
+
+describe('a body that arrives as one string', () => {
+  test('blank lines are the paragraphs', () => {
+    const letter = new CoverLetter({ body: 'First paragraph.\n\nSecond paragraph.\n\n\nThird.' });
+
+    expect(letter.body).toEqual(['First paragraph.', 'Second paragraph.', 'Third.']);
+  });
+
+  test('whitespace is not content', () => {
+    expect(new CoverLetter({ body: '   \n\n  ' }).body).toEqual([]);
+    expect(new CoverLetter({ subject: '   ' }).subject).toBe('');
+  });
+});

--- a/tests/LetterLayout.test.js
+++ b/tests/LetterLayout.test.js
@@ -1,0 +1,144 @@
+import { LetterLayout } from '../adapters/LetterLayout.js';
+import { CoverLetter } from '../domain/CoverLetter.js';
+import { PdfDesignSystem } from '../adapters/PdfDesignSystem.js';
+import { LayoutThemeRegistry } from '../adapters/LayoutThemeRegistry.js';
+
+const MM = 72 / 25.4;
+const format = { width: 595.28, height: 841.89 };
+const theme = new LayoutThemeRegistry().resolve('nerd', 'color');
+const typography = new PdfDesignSystem().resolve(theme);
+const identity = {
+  name: 'Giovanni Trovato',
+  location: 'Bad Liebenstein',
+  email: 'trovato.giovanni@gmail.com',
+  phone: '+39 329 8484 046'
+};
+const strings = {
+  'cv:letter.subject': 'Application',
+  'cv:letter.salutationNamed': 'Dear',
+  'cv:letter.salutationAnonymous': 'Dear Hiring Team',
+  'cv:letter.closing': 'Kind regards,',
+  'cv:letter.attachments': 'Enclosed'
+};
+const t = (key) => strings[key] || key;
+
+const compose = (data, locale = 'en') => new LetterLayout().compose(
+  new CoverLetter(data), { identity, format, theme, typography, t, locale }
+);
+
+const flatten = (node) => {
+  if (node === null || node === undefined) return [];
+  if (typeof node === 'string') return [node];
+  if (Array.isArray(node)) return node.flatMap(flatten);
+  if (typeof node === 'object') {
+    return [...flatten(node.text), ...flatten(node.stack), ...flatten(node.columns)];
+  }
+  return [];
+};
+
+const letter = {
+  recipient: { name: 'Anna Weber', role: 'Talent Lead', company: 'ActAI', address: ['Chausseestraße 1', '10115 Berlin'] },
+  date: '2026-09-09',
+  reference: 'REQ-1042',
+  subject: 'Application for iOS Software Engineer',
+  opening: 'I am writing about the iOS Software Engineer position.',
+  body: ['Six years owning an enterprise MDM client.'],
+  closing: 'I would welcome the chance to talk.',
+  signature: 'Giovanni Trovato',
+  attachments: ['Curriculum vitae']
+};
+
+describe('the page is a DIN 5008 letter', () => {
+  const document = compose(letter);
+
+  // The left margin is what makes an address line up in a window envelope. A letter that
+  // ignores it is a letter someone has to re-fold.
+  test('the margins are the standard, in points', () => {
+    const [left, top, right, bottom] = document.pageMargins;
+
+    expect(left).toBeCloseTo(24.1 * MM, 1);
+    expect(right).toBeCloseTo(20 * MM, 1);
+    expect(top).toBeCloseTo(20 * MM, 1);
+    expect(bottom).toBeCloseTo(20 * MM, 1);
+  });
+
+  test('the address field is the width the standard gives it', () => {
+    const block = document.content.find((node) => Array.isArray(node.columns));
+
+    expect(block.columns[0].width).toBeCloseTo(85 * MM, 1);
+  });
+
+  test('it carries the CV typeface and theme it travels with', () => {
+    expect(document.defaultStyle.font).toBe(typography.defaultStyle.font);
+    expect(document.styles.meta.color).toBe(typography.styles.meta.color);
+  });
+});
+
+describe('what the letter says', () => {
+  const text = flatten(compose(letter).content).join('\n');
+
+  test('the recipient, the company and the reference are all on the page', () => {
+    expect(text).toContain('ActAI');
+    expect(text).toContain('Anna Weber');
+    expect(text).toContain('REQ-1042');
+  });
+
+  test('the sender can be written back to', () => {
+    expect(text).toContain('trovato.giovanni@gmail.com');
+  });
+
+  // The name is deliberately not one of these: it appears in the sender line too, which is
+  // correct on a letter and useless as a position marker.
+  test('the subject, the body and the close are in reading order', () => {
+    const order = ['ActAI', 'Application for iOS Software Engineer', 'Dear Anna Weber',
+      'Six years owning', 'I would welcome', 'Kind regards', 'Enclosed'];
+    const positions = order.map((fragment) => text.indexOf(fragment));
+
+    expect(positions.every((at, index) => at >= 0 && (index === 0 || at > positions[index - 1]))).toBe(true);
+  });
+});
+
+describe('the salutation comes from the catalogue, the name from the model', () => {
+  test('a named recipient is addressed by name', () => {
+    expect(flatten(compose(letter).content).join('\n')).toContain('Dear Anna Weber,');
+  });
+
+  // Nothing invents a name. Without one the letter opens the way the catalogue says.
+  test('an unnamed recipient gets the anonymous opening, not an invented name', () => {
+    const text = flatten(compose({ ...letter, recipient: { company: 'ActAI' } }).content).join('\n');
+
+    expect(text).toContain('Dear Hiring Team,');
+    expect(text).not.toContain('Dear ,');
+  });
+});
+
+describe('the date is formatted, never spelled', () => {
+  // AGENTS.md gives dates to Intl. A German letter dated in American order was not written
+  // for its reader.
+  test('English and German render the same date differently', () => {
+    const english = flatten(compose(letter, 'en').content).join('\n');
+    const german = flatten(compose(letter, 'de').content).join('\n');
+
+    expect(english).toMatch(/September 9, 2026|9 September 2026/);
+    expect(german).toMatch(/9\. September 2026/);
+  });
+
+  test('an unparseable date is printed as written rather than dropped', () => {
+    expect(flatten(compose({ ...letter, date: 'next Tuesday' }).content).join('\n'))
+      .toContain('next Tuesday');
+  });
+});
+
+describe('the close holds together', () => {
+  test('the signature cannot be orphaned onto another page', () => {
+    const close = compose(letter).content.find((node) => node.unbreakable);
+
+    expect(close).toBeDefined();
+    expect(flatten(close).join(' ')).toContain('Giovanni Trovato');
+  });
+
+  test('a letter with no attachments says nothing about attachments', () => {
+    expect(flatten(compose({ ...letter, attachments: [] }).content).join('\n'))
+      .not.toContain('Enclosed');
+  });
+});


### PR DESCRIPTION
Sprint 3, on its own branch and its own pull request — because thirteen tickets sat in
`in-review` against a seventy-commit container that nobody could review, and a ticket in review
should point at something a person can read.

**Stacked on `cv-2026-update`**, which is still open as #1. Merging that first would flatten this;
until then the diff here is only sprint 3's work.

## What it delivers

**Epic C — advert matching.** Paste a job advert, and every term it demands is placed: found in
the prose of a role, found only in the skills list, or absent. Matching runs against the structure
a stranger's parser *recovered*, not against the authored JSON, which is what lets it split every
gap in two — `authored yes / recovered no` is a layout defect and belongs to the renderer;
`authored no` is a content gap and belongs to a human decision.

**Epic D — the cover letter.** The fourth artefact: a designed one-page PDF beside the CV, in the
theme of whichever layout it accompanies.

## The rule this branch will not break

An absent term is reported as *"absent — the CV does not claim it"* and nothing more. The tool
never suggests adding a term the experience does not support: that boundary is the whole
difference between tailoring a CV and fabricating one, and it is why the two columns are separate.

Closes #15 · Closes #16 · Closes #17 · Closes #18 · Closes #19 · Closes #20

🤖 Generated with [Claude Code](https://claude.com/claude-code)
