### PR TITLE
A ticket is closed by a person, not by a merge

### DIFF
--- a/.agents/harness/ticket-loop.json
+++ b/.agents/harness/ticket-loop.json
@@ -12,6 +12,7 @@
       "done": "status:done"
     },
     "backlog_label": "status:backlog",
+    "_never_autoclose": "Arrived as the template default and is now a decision: a ticket is closed by a person, after the work has been audited. The finished work is judged by an external auditor, and an auditor reads open tickets against a diff \u2014 a ticket a merge closed on its own was never read by anyone. So no commit message and no pull-request body may carry a GitHub closing keyword; write `Refs #N`. tests/TicketsCloseByHand.test.js enforces it on every commit a branch adds to the base.",
     "never_autoclose": true,
     "_sync": "Optional. A secondary view (a board, a dashboard) to realign after every state change. It is NOT the source of truth \u2014 the tracker is. If this command fails the loop SAYS SO and carries on: a stale view is an annoyance, a stalled loop is a blocker.",
     "sync": null,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -136,10 +136,40 @@ A drafted ticket carries:
 - Acceptance criteria taken from the finding's **Prevention** line, so the ticket closes against
   the rule and not against an opinion.
 - The component label, and `status:backlog` unless it is being started immediately.
-- No auto-closing keywords: `board.never_autoclose` is set.
+- No auto-closing keywords, here or anywhere else — see **Who closes a ticket** below.
 
 Filing or reopening a ticket changes the tracker, so it sits behind the loop's ordinary
 `gated` autonomy: propose the ticket, show it, and let a person say go.
+
+### Who closes a ticket
+
+A person does, after the work has been audited. Never a merge.
+
+`board.never_autoclose` in `.agents/harness/ticket-loop.json` says so. It arrived as the harness
+template's default rather than as anyone's decision, and for three sprints the practice
+contradicted it: every commit message ended `Closes #N` and both pull-request bodies repeated the
+list. Thirteen tickets closed themselves the moment pull request #1 merged, still carrying
+`status:in-review` — a label saying a review was pending on work the tracker had already filed
+away. That is issue #37, and the flag is now a decision rather than an inheritance.
+
+The rule, in full:
+
+- **A commit message references a ticket, it does not close one.** Write `Refs #19`. The keywords
+  GitHub acts on are `close`, `fix` and `resolve`, in all three tenses, followed by `#N` or the
+  issue's URL — all nine are forbidden, and `tests/TicketsCloseByHand.test.js` fails on any commit
+  a branch adds to the base branch that uses one.
+- **A pull-request body follows the same rule.** It is merged into the default branch's history
+  and GitHub reads it there too.
+- **Closing is the auditor's act.** An auditor reads an open ticket against a diff. A ticket a
+  merge closed on its own was read by nobody, and reopening it afterwards leaves a timeline that
+  says the work was done twice.
+
+The one exemption is written down where it applies: six commits already merged through pull
+request #31 carry `Closes #15`–`Closes #20`, and rewriting them would orphan the SHAs that pull
+request points at. They are listed in the test by SHA, with the reason, and they will close those
+six tickets when `cv-2026-update` reaches `main` — whoever merges is expected to reopen them.
+Naming the debt is the point: an exemption in a list can be counted, an exemption in a habit
+cannot.
 
 ### Prevention rules become tests where they can
 

--- a/scripts/lib/closing-keyword.mjs
+++ b/scripts/lib/closing-keyword.mjs
@@ -1,0 +1,52 @@
+/**
+ * The GitHub keywords that close an issue, and the rule this project applies to them.
+ *
+ * `board.never_autoclose` in `.agents/harness/ticket-loop.json` says a ticket is closed by a
+ * person, after the work has been audited — never by a merge. A commit message ending
+ * `Closes #19` overrides that silently: the issue closes the moment the commit reaches the
+ * default branch, whatever the board says, and nobody reads a closed ticket.
+ *
+ * This module is the rule on its own, with no git in it, so the check that enforces it can be
+ * shown to fail on a message that breaks it and pass on one that does not.
+ */
+
+/**
+ * The full set GitHub honours, all three tenses of each verb. Anything outside it — `Refs`,
+ * `Part of`, a bare `#19` — references the ticket without touching its state, which is what
+ * this project wants a commit to do.
+ *
+ * @see https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue
+ */
+export const CLOSING_KEYWORDS = [
+  'close', 'closes', 'closed',
+  'fix', 'fixes', 'fixed',
+  'resolve', 'resolves', 'resolved'
+];
+
+/**
+ * The reference GitHub acts on: a keyword, whitespace, then `#<number>` or the issue's URL.
+ * Case-insensitive, because GitHub is. A hash inside a word (`ab#12`) is not a reference, hence
+ * the boundary before it.
+ */
+const REFERENCE = new RegExp(
+  `\\b(${CLOSING_KEYWORDS.join('|')})\\b[\\s:]+` +
+  '(?:https?://\\S*?/issues/(\\d+)|#(\\d+))',
+  'gi'
+);
+
+/**
+ * Every closing reference in one commit message or pull-request body.
+ *
+ * @param {string} message
+ * @returns {Array<{keyword: string, issue: number}>} in the order they appear; empty when the
+ *   message names tickets without claiming to close them.
+ */
+export function closingReferences(message = '') {
+  return [...String(message).matchAll(REFERENCE)].map((match) => ({
+    keyword: match[1],
+    issue: Number(match[2] ?? match[3])
+  }));
+}
+
+/** The phrasing to use instead. Named here so the failure message can suggest it. */
+export const NON_CLOSING_PREFIX = 'Refs';

--- a/tests/TicketsCloseByHand.test.js
+++ b/tests/TicketsCloseByHand.test.js
@@ -1,0 +1,96 @@
+/**
+ * @jest-environment node
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { closingReferences, CLOSING_KEYWORDS, NON_CLOSING_PREFIX } from '../scripts/lib/closing-keyword.mjs';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const git = (...args) => execFileSync('git', args, { cwd: root, encoding: 'utf8' }).trim();
+const manifest = JSON.parse(readFileSync(new URL('../.agents/harness/ticket-loop.json', import.meta.url)));
+
+/**
+ * The six commits that carried `Closes #15`–`Closes #20` onto `cv-2026-update` before this rule
+ * existed. They are merged already, through pull request #31, so rewriting them would orphan the
+ * SHAs that pull request points at — a worse trade than naming the debt.
+ *
+ * They will close their tickets when `cv-2026-update` reaches `main`. Issue #37 says so, and
+ * whoever merges is expected to reopen them for the auditor. Once they are on the base branch
+ * they leave the range this check inspects and these lines can be deleted.
+ */
+const MERGED_BEFORE_THE_RULE = [
+  '19b19f33fa34b93c08e466803a3229eb3a95b2de', // feat: a lexicon for job adverts — Closes #15
+  'a9f42df263647b88ab84841a83c12591d8e68d6b', // feat: extract what an advert asks for — Closes #16
+  '8ab9a9a92e91dd4d0913ce2ce7dc5fbf741ac733', // feat: separate a layout defect from a gap — Closes #17
+  'ae1b00f470f23812401f26387149f19aa276f7a7', // feat: model a cover letter — Closes #18
+  'e5ea8e381368910b24659776bb4e385d4f92c9eb', // feat: lay out a cover letter on DIN 5008 — Closes #19
+  '8cef3927dfa8bfafa42e80d0da219054239910fd'  // feat: generate the letter with the CV — Closes #20
+];
+
+describe('the rule about closing keywords', () => {
+  // The check has to be able to fail, and this is where that is proved: a message with the
+  // keyword is caught, the same message with `Refs` is not. Without this pair, a predicate that
+  // returned nothing at all would pass the repository check below on any history.
+  test.each(CLOSING_KEYWORDS)('`%s #19` closes a ticket', (keyword) => {
+    expect(closingReferences(`feat: something\n\n${keyword} #19`))
+      .toEqual([{ keyword, issue: 19 }]);
+  });
+
+  test(`\`${NON_CLOSING_PREFIX} #19\` does not`, () => {
+    expect(closingReferences(`feat: something\n\n${NON_CLOSING_PREFIX} #19`)).toEqual([]);
+  });
+
+  test('a bare number and a hash inside a word are not references', () => {
+    expect(closingReferences('feat: bump to 19\n\nSee ab#19')).toEqual([]);
+  });
+});
+
+describe('a ticket is closed by a person, not by a merge', () => {
+  // `board.never_autoclose` is the setting this check exists to keep honest. Reading it here
+  // rather than assuming it means the two cannot drift: turn the flag off and the check stops
+  // applying, which is a decision someone made in the manifest and can be seen there.
+  test('the board still says a merge must not close a ticket', () => {
+    expect(manifest.board.never_autoclose).toBe(true);
+  });
+
+  // Full SHAs, and no duplicates. Existence is deliberately not asserted: the objects are only
+  // guaranteed present in a clone that fetched `cv-2026-update`, and a wrong SHA here cannot hide
+  // a violation — it exempts nothing, and the check below goes red naming the commit.
+  test('the exemptions are full SHAs, listed once each', () => {
+    const malformed = MERGED_BEFORE_THE_RULE.filter((sha) => !/^[0-9a-f]{40}$/.test(sha));
+
+    expect(malformed).toEqual([]);
+    expect(new Set(MERGED_BEFORE_THE_RULE).size).toBe(MERGED_BEFORE_THE_RULE.length);
+  });
+
+  // The commits this branch would add to the base. On the base branch itself that set is empty
+  // and the check passes trivially; on a branch about to be merged it is exactly the history a
+  // merge would push to the default branch, which is when GitHub acts on the keywords.
+  test('no commit this branch adds closes a ticket', () => {
+    const base = manifest.vcs.base_branch;
+    // An audit that could not run must never read as a pass — the mistake audit-print made for
+    // weeks. If neither ref resolves, say so instead of reporting green.
+    // The remote's base branch first: it is what a merge actually targets, and a local `main`
+    // left behind by a fetch-less week would put commits already on the default branch back into
+    // the range and fail on history nobody is about to push.
+    const ref = [`origin/${base}`, base].find((candidate) => {
+      try {
+        git('rev-parse', '--verify', '--quiet', `${candidate}^{commit}`);
+        return true;
+      } catch {
+        return false;
+      }
+    });
+    expect(ref).toBeDefined();
+
+    const offenders = git('log', '--format=%H', `${ref}..HEAD`)
+      .split('\n')
+      .filter(Boolean)
+      .filter((sha) => !MERGED_BEFORE_THE_RULE.includes(sha))
+      .flatMap((sha) => closingReferences(git('log', '-1', '--format=%B', sha))
+        .map(({ keyword, issue }) => `${sha.slice(0, 7)} ${keyword} #${issue}`));
+
+    expect(offenders).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What was contradictory

`board.never_autoclose` has been `true` since the harness was installed, while every commit
message in three sprints ended with a GitHub closing keyword and both pull-request bodies
repeated the list. The setting was never anyone's decision — it is the harness template's
default, which arrived in `592e140` and was never read again.

The contradiction has already been paid for: when pull request #1 merged, thirteen tickets
closed themselves while still carrying `status:in-review`. The board says a review is pending
on work the tracker has filed away.

## The decision

The flag stays `true`, because it matches how this work is judged: an external auditor reads an
**open** ticket against a diff. A ticket a merge closed on its own was read by nobody, and
reopening it afterwards leaves a timeline saying the work happened twice.

So the practice changes, not the setting. A commit references a ticket with `Refs #N` and never
closes one; the same rule applies to pull-request bodies, which GitHub also reads once they are
in the default branch's history.

## What enforces it

`tests/TicketsCloseByHand.test.js` fails on any commit a branch adds to the base branch that
carries one of the nine keywords GitHub acts on, in any tense, by `#N` or by issue URL.

- It reads the base branch **from the manifest**, so the check and the setting cannot drift.
- It prefers `origin/<base>`: a local `main` left behind by a fetch-less week would put commits
  already on the default branch back into the range.
- It fails loudly when neither ref resolves — an audit that could not run must never read as a
  pass, which is the mistake `audit:print` made for weeks.
- The rule itself lives in `scripts/lib/closing-keyword.mjs` with no git in it, so the suite can
  show it catching a bad message and passing a good one. Without that pair, a predicate that
  matched nothing would pass on any history.

It caught the first draft of its own commit message, which quoted two keywords verbatim and
would have closed two tickets on merge.

## The debt it does not pretend away

Six commits already merged through pull request #31 still carry closing keywords for tickets 15
to 20. Rewriting them would orphan the SHAs that pull request points at, so they are exempted by
SHA, in a list, with the reason written beside each one. They will close those six tickets when
`cv-2026-update` reaches `main`, and whoever merges is expected to reopen them.

An exemption in a list can be counted. An exemption in a habit cannot.

## Verification

`npm test` — 267 passing, 14 of them new.

Refs #37
