### PR TITLE
Load the public CV again: declare certifications once

### DIFF
--- a/adapters/PdfLayout.js
+++ b/adapters/PdfLayout.js
@@ -96,24 +96,19 @@ export class PdfLayout {
       text: [{ text: `${item.name}: `, bold: true }, item.level],
       margin: [0, 0, 0, 6]
     }));
+    // Without a description, the spacing moves onto the name line instead of an empty paragraph.
     const certifications = model.certifications.map((item) => ({
       stack: [
         {
           text: `${item.name} — ${item.issuer} (${item.year})`,
           bold: true,
           color: theme.ink,
-          ...(item.url ? { link: item.url } : {})
+          ...(item.url ? { link: item.url } : {}),
+          ...(item.description ? {} : { margin: [0, 0, 0, 6] })
         },
-        { text: item.description, margin: [0, 3, 0, 6] }
+        ...(item.description ? [{ text: item.description, margin: [0, 3, 0, 6] }] : [])
       ]
     }));
-    // Without a description, the spacing moves onto the name line instead of an empty paragraph.
-    const certifications = model.certifications.map((item) => ({ stack: [
-      { text: `${item.name} — ${item.issuer} (${item.year})`, bold: true, color: theme.ink,
-        ...(item.url ? { link: item.url } : {}),
-        ...(item.description ? {} : { margin: [0, 0, 0, 6] }) },
-      ...(item.description ? [{ text: item.description, margin: [0, 3, 0, 6] }] : [])
-    ] }));
     // The address, not the platform name. A PDF link annotation carries the URL but the text
     // layer carries only what was drawn, so "GitHub" over a hyperlink extracts as "GitHub" and
     // the parsed record has no address at all — five links, none of them recoverable. Printed,

--- a/tests/PdfExporter.test.js
+++ b/tests/PdfExporter.test.js
@@ -194,7 +194,10 @@ describe('PdfExporter — what has to survive extraction and assistive reading',
   // The web page already skips a missing description. The PDF reserved a paragraph for it anyway,
   // and on spotlight LETTER one reserved line is the difference between two pages and three.
   test('omits a certification description rather than rendering an empty line', () => {
-    const bare = { ...rich, certifications: [{ name: 'iOS Lead Essentials', issuer: 'Academy', year: 2024 }] };
+    const bare = {
+      ...rich,
+      certifications: [{ name: 'iOS Lead Essentials', issuer: 'Academy', year: 2024 }]
+    };
     const definition = new PdfExporter(null, { t: (key) => key }).buildDocument(bare, 'nerd');
     const carriers = [...walk(definition.content)].filter((node) => 'text' in node);
     expect(carriers.length).toBeGreaterThan(0);


### PR DESCRIPTION
The public CV renders empty. Refs #63.

## What broke

The merge of #52 kept both sides of its conflict in `adapters/PdfLayout.js`, so `const certifications` was declared twice in the same scope.

- A module with a duplicate declaration does not parse.
- `script.js` imports it through `core/PdfExporter.js`, so no renderer runs and every layout shows an empty page.
- GitHub Pages built that merge, `be4c054`, at 07:42 on 2026-09-11. The live `adapters/PdfLayout.js` carries both declarations, and Chrome logs `Uncaught SyntaxError: Identifier 'certifications' has already been declared`.

## The change

- `adapters/PdfLayout.js` keeps the declaration from a5f87a9, which leaves out a certification's description line when there is none, and loses the earlier one.
- `adapters/PdfLayout.js` and `tests/PdfExporter.test.js` are formatted again, as `tests/SourceIsFormatted.test.js` requires.

## Verified

- **`npm test`:** 41 suites, 345 tests pass. On `main`, `PdfExporter.test.js` did not run and the formatting check failed.
- **`npm run audit:print`:** 12/12 on two pages for nerd, spotlight and technical, and `docs/PRINT_AUDIT.md` comes out unchanged. On `main` every layout scored 6/12 on one page, because the page never rendered.

Nothing ran the gates between the merge and the deploy; #28 and #45 are about that.
