### PR TITLE
Show Nerd Mode as a Swift file in an editor, with a contact card on a phone

### DIFF
--- a/adapters/PdfLayout.js
+++ b/adapters/PdfLayout.js
@@ -96,24 +96,19 @@ export class PdfLayout {
       text: [{ text: `${item.name}: `, bold: true }, item.level],
       margin: [0, 0, 0, 6]
     }));
+    // Without a description, the spacing moves onto the name line instead of an empty paragraph.
     const certifications = model.certifications.map((item) => ({
       stack: [
         {
           text: `${item.name} — ${item.issuer} (${item.year})`,
           bold: true,
           color: theme.ink,
-          ...(item.url ? { link: item.url } : {})
+          ...(item.url ? { link: item.url } : {}),
+          ...(item.description ? {} : { margin: [0, 0, 0, 6] })
         },
-        { text: item.description, margin: [0, 3, 0, 6] }
+        ...(item.description ? [{ text: item.description, margin: [0, 3, 0, 6] }] : [])
       ]
     }));
-    // Without a description, the spacing moves onto the name line instead of an empty paragraph.
-    const certifications = model.certifications.map((item) => ({ stack: [
-      { text: `${item.name} — ${item.issuer} (${item.year})`, bold: true, color: theme.ink,
-        ...(item.url ? { link: item.url } : {}),
-        ...(item.description ? {} : { margin: [0, 0, 0, 6] }) },
-      ...(item.description ? [{ text: item.description, margin: [0, 3, 0, 6] }] : [])
-    ] }));
     // The address, not the platform name. A PDF link annotation carries the URL but the text
     // layer carries only what was drawn, so "GitHub" over a hyperlink extracts as "GitHub" and
     // the parsed record has no address at all — five links, none of them recoverable. Printed,

--- a/adapters/SwiftSourceLayout.js
+++ b/adapters/SwiftSourceLayout.js
@@ -443,6 +443,10 @@ export class SwiftSourceLayout {
    * The actions are the ways a card offers to reach someone — call, mail, then the profile's links
    * — up to one row of four, and each one goes somewhere: a button that does nothing reads as a
    * broken page.
+   *
+   * "call" is the page's one easter egg, the candidate's own: it opens an alert with the number
+   * and a nudge to dial it yourself. The number stays a `tel:` link in the file and in the
+   * card's details, so nobody who wants to call is kept from it.
    */
   card(data, t) {
     const phone = clean(data.phone);
@@ -456,7 +460,7 @@ export class SwiftSourceLayout {
               icon: 'phone',
               label: t('source.card.call'),
               name: t('source.card.callName', { value: phone }),
-              href: telephone(phone)
+              dialog: 'call'
             }
           ]
         : []),
@@ -497,6 +501,10 @@ export class SwiftSourceLayout {
       ...(location ? [{ kind: 'location', label: t('source.card.location'), value: location }] : [])
     ];
 
-    return { name: clean(data.name), title: clean(data.title), actions, rows };
+    const call = phone
+      ? { title: phone, message: t('source.card.callJoke'), dismiss: t('source.card.callDismiss') }
+      : null;
+
+    return { name: clean(data.name), title: clean(data.title), call, actions, rows };
   }
 }

--- a/adapters/SwiftSourceLayout.js
+++ b/adapters/SwiftSourceLayout.js
@@ -1,0 +1,423 @@
+/**
+ * How the CV reads as a Swift file, for Nerd Mode on screen — and what that file's #Preview shows.
+ *
+ * The sibling of `adapters/PdfLayout.js` for a different surface: it turns the profile into
+ * lines of tokens, and `renderers/SourceRenderer.js` only writes them into the page. Every token
+ * is one of two things, and the difference is the whole design:
+ *
+ * - `{ code }` is syntax — a keyword, a quote, a bracket, an argument label. The renderer never
+ *   puts it into the document; the stylesheet draws it. A screen reader, a selection and a search
+ *   never meet it.
+ * - `{ text }` is the CV, exactly as the data wrote it. It is the only real text the file has.
+ *
+ * So the page can look like source code without a single word of Swift reaching anything that
+ * reads the document, which is the rule `AGENTS.md` sets for every visual device here: removing
+ * the stylesheet removes the decoration and never the meaning.
+ *
+ * The file is written the way Swift is written — a multi-line string for the summary, an
+ * initialiser per role with its achievements in a trailing closure, a result builder for the
+ * skills — because a reader who writes Swift notices a file that reads wrong. It does not have to
+ * compile: `Engineer`, `Role` and `SkillSet` are names, not a library.
+ *
+ * `card` is the contact card the phone beside the editor shows: the name, the role and the ways to
+ * reach the candidate. Every word on it is already in the file, so the renderer draws it too.
+ *
+ * It takes the raw profile, as every page renderer does, and knows nothing about the DOM.
+ */
+import { readableAddress } from '../domain/ReadableUrl.js';
+
+const SECTIONS = ['skills', 'experience', 'certifications', 'education', 'languages', 'interests'];
+
+/** A phone screen has room for four buttons across; a fifth would wrap into a second row. */
+const CARD_ACTIONS = 4;
+
+const code = (value, kind = 'plain') => ({ code: value, kind });
+const content = (value, kind, extra = {}) => ({ text: value, kind, ...extra });
+const clean = (value) => (value === undefined || value === null ? '' : String(value).trim());
+const list = (value) => (Array.isArray(value) ? value.filter(Boolean) : []);
+
+/** A string literal. The quotes are syntax; what is between them is the data. */
+const quoted = (value, extra = {}) =>
+  value === ''
+    ? [code('""', 'string')]
+    : [code('"', 'string'), content(value, 'string', extra), code('"', 'string')];
+
+const comma = (last) => (last ? [] : [code(',')]);
+
+const arrayOf = (type) => [code('['), code(type, 'type'), code(']')];
+
+const arrayLiteral = (values) => [
+  code('['),
+  ...values.flatMap((value, index) => [...(index > 0 ? [code(', ')] : []), ...quoted(value)]),
+  code(']')
+];
+
+/** `let name = `, or `let name: Type = ` when a type is given. */
+const declaration = (keyword, name, type = []) => [
+  code(`${keyword} `, 'keyword'),
+  code(name, 'property'),
+  ...(type.length > 0 ? [code(': '), ...type] : []),
+  code(' = ')
+];
+
+/** An argument as the data gave it: a number stays a number, a list keeps what is not empty. */
+const normalise = (value) => {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (Array.isArray(item) ? item : clean(item)))
+      .filter((item) => item.length > 0);
+  }
+  return Number.isFinite(value) ? value : clean(value);
+};
+
+/** Lines are `[depth, tokens, extra]` until `compose` places them; this moves a block inward. */
+const indent = (lines, by = 1) =>
+  lines.map(([depth, tokens, extra]) => [depth + by, tokens, extra]);
+
+/**
+ * The candidate's name as a Swift type: each word capitalised and run together, apostrophes
+ * dropped, anything that cannot be part of an identifier removed. Letters outside ASCII stay —
+ * Swift identifiers are Unicode, and "Núñez" is not "Nunez".
+ * @param {string} name - The name as the profile writes it
+ * @returns {string} A type name
+ */
+export function swiftTypeName(name) {
+  const words = clean(name)
+    .normalize('NFC')
+    .replace(/['’]/g, '')
+    .split(/[^\p{L}\p{N}]+/u)
+    .filter(Boolean);
+  const joined = words.map((word) => word[0].toLocaleUpperCase() + word.slice(1)).join('');
+  if (!joined) return 'Curriculum';
+  return /^\p{N}/u.test(joined) ? `CV${joined}` : joined;
+}
+
+export class SwiftSourceLayout {
+  /**
+   * @param {object} data - the profile, as the page renderers receive it
+   * @param {object} context - `t`, the translator, already bound by the caller
+   * @returns {{ typeName: string, fileName: string, lines: object[], outline: object[],
+   *   card: object }} `lines` are `{ depth, tokens }`, plus `heading` and `id` on a section mark
+   *   and `current` on the line the editor opens on; `outline` is the sections written, in order;
+   *   `card` is what the preview shows
+   */
+  compose(data = {}, { t = (key) => key } = {}) {
+    const typeName = swiftTypeName(data.name);
+    const lines = [];
+    const outline = [];
+    const push = (depth, tokens = [], extra = {}) =>
+      lines.push({ depth: tokens.length === 0 ? 0 : depth, tokens, ...extra });
+    const section = (key, label, body) => {
+      if (body.length === 0) return;
+      if (outline.length > 0) push(0);
+
+      const id = `source-${key}`;
+      push(1, [code('// MARK: - ', 'mark'), content(label, 'mark')], { heading: 2, id });
+      push(0);
+      body.forEach(([depth, tokens, extra]) => push(1 + depth, tokens, extra));
+      outline.push({ id, label });
+    };
+
+    push(0, [code('//', 'comment')]);
+    push(0, [code(`//  ${typeName}.swift`, 'comment')]);
+    push(0, [code('//  CV', 'comment')]);
+    push(0, [code('//', 'comment')]);
+    push(0);
+    push(0, [code('import ', 'keyword'), code('SwiftUI', 'type')]);
+    push(0);
+    push(0, [
+      code('struct ', 'keyword'),
+      code(typeName, 'type'),
+      code(': '),
+      code('Engineer', 'type'),
+      code(' {')
+    ]);
+
+    section('profile', t('source.marks.profile'), this.profile(data));
+    section('contact', t('source.marks.contact'), this.contact(data));
+    SECTIONS.forEach((key) => section(key, t(`cv:sections.${key}`), this[key](data)));
+
+    push(0, [code('}')]);
+    push(0);
+    push(0, [code('#Preview', 'macro'), code(' {')]);
+    push(1, [
+      code('ContactCard', 'call'),
+      code('('),
+      code('for: ', 'label'),
+      code(typeName, 'type'),
+      code('())')
+    ]);
+    push(2, [
+      code('.'),
+      code('preferredColorScheme', 'call'),
+      code('('),
+      code('.'),
+      code('dark', 'property'),
+      code(')')
+    ]);
+    push(0, [code('}')]);
+
+    return {
+      typeName,
+      fileName: `${typeName}.swift`,
+      lines,
+      outline,
+      card: this.card(data, t)
+    };
+  }
+
+  profile(data) {
+    const string = (name, value, extra = {}) => [
+      ...declaration('let', name),
+      ...quoted(value, extra)
+    ];
+    const [name, title, focus, summary, availability] = [
+      data.name,
+      data.title,
+      data.subtitle,
+      data.profile,
+      data.availability
+    ].map(clean);
+
+    const lines = [];
+    if (name) lines.push([0, string('name', name, { element: 'h1' }), { current: true }]);
+    if (title) lines.push([0, string('title', title)]);
+    if (focus) lines.push([0, string('focus', focus)]);
+    if (summary) {
+      // A paragraph is a multi-line string in Swift: the delimiters take lines of their own.
+      lines.push([0, [...declaration('let', 'summary'), code('"""', 'string')]]);
+      lines.push([1, [content(summary, 'string')]]);
+      lines.push([1, [code('"""', 'string')]]);
+    }
+    if (availability) lines.push([0, string('availability', availability)]);
+    return lines;
+  }
+
+  contact(data) {
+    const links = list(data.social)
+      .filter((link) => clean(link.url) !== '')
+      .map((link) => {
+        const address = readableAddress(link.url);
+        return [
+          code('Link', 'call'),
+          code('('),
+          ...quoted(clean(link.platform) || address),
+          code(', '),
+          code('url: ', 'label'),
+          ...quoted(address, { element: 'a', href: clean(link.url) }),
+          code(')')
+        ];
+      });
+
+    return this.call(
+      'Contact',
+      [
+        ['location', data.location],
+        ['email', data.email],
+        ['phone', data.phone],
+        ['links', links]
+      ],
+      { prefix: declaration('let', 'contact'), close: '' }
+    );
+  }
+
+  skills(data) {
+    const skills = list(data.skills);
+    const names = (items) => items.map((item) => clean(item && item.name)).filter(Boolean);
+
+    if (!skills.some((entry) => Array.isArray(entry.items))) {
+      const flat = names(skills);
+      if (flat.length === 0) return [];
+      return [[0, [...declaration('let', 'skills', arrayOf('String')), ...arrayLiteral(flat)]]];
+    }
+
+    const groups = skills
+      .filter((entry) => Array.isArray(entry.items))
+      .map((entry) => ({ category: clean(entry.category), names: names(entry.items) }))
+      .filter((group) => group.names.length > 0);
+    if (groups.length === 0) return [];
+
+    // A result builder, the way SwiftUI groups children: one block per category.
+    return [
+      [
+        0,
+        [
+          code('var ', 'keyword'),
+          code('skills', 'property'),
+          code(': '),
+          code('some ', 'keyword'),
+          code('SkillSet', 'type'),
+          code(' {')
+        ]
+      ],
+      ...groups.flatMap((group) => [
+        [1, [code('Category', 'call'), code('('), ...quoted(group.category), code(') {')]],
+        [2, arrayLiteral(group.names)],
+        [1, [code('}')]]
+      ]),
+      [0, [code('}')]]
+    ];
+  }
+
+  experience(data) {
+    return this.collection(
+      'experience',
+      'Role',
+      list(data.relevant_experience).map((role) =>
+        this.call(
+          'Role',
+          [
+            ['title', role.title, { element: 'h3' }],
+            ['company', role.company],
+            ['location', role.location],
+            ['period', role.period],
+            ['summary', role.summary],
+            ['description', role.description]
+          ],
+          { trailing: list(role.highlights) }
+        )
+      )
+    );
+  }
+
+  certifications(data) {
+    return this.collection(
+      'certifications',
+      'Certification',
+      list(data.certifications).map((certification) => {
+        const url = clean(certification.url);
+        return this.call('Certification', [
+          ['name', certification.name, url ? { element: 'a', href: url } : {}],
+          ['issuer', certification.issuer],
+          ['year', certification.year],
+          ['description', certification.description]
+        ]);
+      })
+    );
+  }
+
+  education(data) {
+    return this.collection(
+      'education',
+      'Degree',
+      list(data.education).map((degree) =>
+        this.call('Degree', [
+          ['title', degree.degree],
+          ['school', degree.school],
+          ['period', degree.period],
+          ['description', degree.description]
+        ])
+      )
+    );
+  }
+
+  languages(data) {
+    const languages = list(data.languages).filter((language) => clean(language.name) !== '');
+    if (languages.length === 0) return [];
+
+    const pairs = [
+      code('KeyValuePairs', 'type'),
+      code('<'),
+      code('String', 'type'),
+      code(', '),
+      code('String', 'type'),
+      code('>')
+    ];
+    return [
+      [0, [...declaration('let', 'languages', pairs), code('[')]],
+      ...languages.map((language) => [
+        1,
+        [...quoted(clean(language.name)), code(': '), ...quoted(clean(language.level)), code(',')]
+      ]),
+      [0, [code(']')]]
+    ];
+  }
+
+  interests(data) {
+    const interests = list(data.interests).map(clean).filter(Boolean);
+    if (interests.length === 0) return [];
+    return [
+      [0, [...declaration('let', 'interests', arrayOf('String')), ...arrayLiteral(interests)]]
+    ];
+  }
+
+  /** `let name: [Type] = [` an entry per block `]`, or nothing when there are no entries. */
+  collection(name, type, entries) {
+    const present = entries.filter((entry) => entry.length > 0);
+    if (present.length === 0) return [];
+    return [
+      [0, [...declaration('let', name, arrayOf(type)), code('[')]],
+      ...present.flatMap((entry) => indent(entry)),
+      [0, [code(']')]]
+    ];
+  }
+
+  /**
+   * An initialiser across several lines, one argument a line. An empty argument is left out
+   * rather than written as `""`: a role with no description has no description, not a blank one.
+   * A list argument opens its own block. A number in the data is a number literal; a string that
+   * looks like one — a period of "2009" — stays a string, because that is what was written.
+   * `trailing` strings become a trailing closure, one a line, the shape SwiftUI gives children.
+   */
+  call(type, args, { prefix = [], close = ',', trailing = [] } = {}) {
+    const present = args
+      .map(([label, value, extra = {}]) => [label, normalise(value), extra])
+      .filter(([, value]) => (Array.isArray(value) ? value.length > 0 : value !== ''));
+    const children = trailing.map(clean).filter(Boolean);
+    if (present.length === 0 && children.length === 0) return [];
+
+    const head = [...prefix, code(type, 'call')];
+    const closure = [...children.map((child) => [1, quoted(child)]), [0, [code(`}${close}`)]]];
+    if (present.length === 0) return [[0, [...head, code(' {')]], ...closure];
+
+    const body = present.flatMap(([label, value, extra], index) => {
+      const last = index === present.length - 1;
+      const name = code(`${label}: `, 'label');
+
+      if (Array.isArray(value)) {
+        return [
+          [1, [name, code('[')]],
+          ...value.map((item) => [2, [...(Array.isArray(item) ? item : quoted(item)), code(',')]]),
+          [1, [code(']'), ...comma(last)]]
+        ];
+      }
+
+      const literal =
+        typeof value === 'number'
+          ? [content(String(value), 'number', extra)]
+          : quoted(value, extra);
+      return [[1, [name, ...literal, ...comma(last)]]];
+    });
+
+    const end =
+      children.length === 0 ? [[0, [code(`)${close}`)]]] : [[0, [code(') {')]], ...closure];
+    return [[0, [...head, code('(')]], ...body, ...end];
+  }
+
+  /**
+   * The contact card the preview renders: the name, the role, a row of actions and the details.
+   * The actions are the ways a card offers to reach someone — call, mail, then the profile's links
+   * — up to one row of four.
+   */
+  card(data, t) {
+    const phone = clean(data.phone);
+    const email = clean(data.email);
+    const location = clean(data.location);
+
+    const actions = [
+      ...(phone ? [{ icon: 'phone', label: t('source.card.call') }] : []),
+      ...(email ? [{ icon: 'mail', label: t('source.card.mail') }] : []),
+      ...list(data.social)
+        .filter((link) => clean(link.url) !== '' && clean(link.platform) !== '')
+        .map((link) => ({ icon: 'link', label: clean(link.platform) }))
+    ].slice(0, CARD_ACTIONS);
+
+    const rows = [
+      ...(phone ? [{ kind: 'phone', label: t('cv:contacts.phone'), value: phone }] : []),
+      ...(email ? [{ kind: 'email', label: t('cv:contacts.email'), value: email }] : []),
+      ...(location ? [{ kind: 'location', label: t('source.card.location'), value: location }] : [])
+    ];
+
+    return { name: clean(data.name), title: clean(data.title), actions, rows };
+  }
+}

--- a/adapters/SwiftSourceLayout.js
+++ b/adapters/SwiftSourceLayout.js
@@ -8,11 +8,14 @@
  * - `{ code }` is syntax — a keyword, a quote, a bracket, an argument label. The renderer never
  *   puts it into the document; the stylesheet draws it. A screen reader, a selection and a search
  *   never meet it.
- * - `{ text }` is the CV, exactly as the data wrote it. It is the only real text the file has.
+ * - `{ text }` is the CV, exactly as the data wrote it — and the punctuation between two of its
+ *   words on one line, the comma between two skills and the colon between a language and its
+ *   level. Drawn, that punctuation vanished from a selection and "Swift, SwiftUI" copied as
+ *   "SwiftSwiftUI"; the product review measured it in Chrome.
  *
- * So the page can look like source code without a single word of Swift reaching anything that
- * reads the document, which is the rule `AGENTS.md` sets for every visual device here: removing
- * the stylesheet removes the decoration and never the meaning.
+ * So the page can look like source code without a word of Swift reaching anything that reads the
+ * document, which is the rule `AGENTS.md` sets for every visual device here: removing the
+ * stylesheet removes the decoration and never the meaning.
  *
  * The file is written the way Swift is written — a multi-line string for the summary, an
  * initialiser per role with its achievements in a trailing closure, a result builder for the
@@ -20,19 +23,41 @@
  * compile: `Engineer`, `Role` and `SkillSet` are names, not a library.
  *
  * `card` is the contact card the phone beside the editor shows: the name, the role and the ways to
- * reach the candidate. Every word on it is already in the file, so the renderer draws it too.
+ * reach the candidate, each with somewhere to go.
  *
  * It takes the raw profile, as every page renderer does, and knows nothing about the DOM.
  */
 import { readableAddress } from '../domain/ReadableUrl.js';
 
-const SECTIONS = ['skills', 'experience', 'certifications', 'education', 'languages', 'interests'];
+/**
+ * Who the candidate is comes first, then the evidence — experience before skills — and last how
+ * to reach them, which the card beside the file already offers. With the contact block and the
+ * skills ahead of it, the current employer sat 1.8 to 3.9 screens down.
+ */
+const SECTIONS = [
+  'profile',
+  'experience',
+  'skills',
+  'certifications',
+  'education',
+  'languages',
+  'interests',
+  'contact'
+];
+
+/** Section labels shared with the other outputs, or the editor's own for the two it adds. */
+const LABELS = {
+  profile: 'source.marks.profile',
+  contact: 'source.marks.contact'
+};
 
 /** A phone screen has room for four buttons across; a fifth would wrap into a second row. */
 const CARD_ACTIONS = 4;
 
 const code = (value, kind = 'plain') => ({ code: value, kind });
 const content = (value, kind, extra = {}) => ({ text: value, kind, ...extra });
+/** Punctuation that separates two words on one line: real text, so a copy keeps it. */
+const between = (value) => content(value, 'plain');
 const clean = (value) => (value === undefined || value === null ? '' : String(value).trim());
 const list = (value) => (Array.isArray(value) ? value.filter(Boolean) : []);
 
@@ -48,7 +73,7 @@ const arrayOf = (type) => [code('['), code(type, 'type'), code(']')];
 
 const arrayLiteral = (values) => [
   code('['),
-  ...values.flatMap((value, index) => [...(index > 0 ? [code(', ')] : []), ...quoted(value)]),
+  ...values.flatMap((value, index) => [...(index > 0 ? [between(', ')] : []), ...quoted(value)]),
   code(']')
 ];
 
@@ -73,6 +98,9 @@ const normalise = (value) => {
 /** Lines are `[depth, tokens, extra]` until `compose` places them; this moves a block inward. */
 const indent = (lines, by = 1) =>
   lines.map(([depth, tokens, extra]) => [depth + by, tokens, extra]);
+
+/** A number a phone can dial: the digits and a leading plus, nothing a person types to read it. */
+const telephone = (number) => `tel:${number.replace(/[^\d+]/g, '')}`;
 
 /**
  * The candidate's name as a Swift type: each word capitalised and run together, apostrophes
@@ -107,21 +135,8 @@ export class SwiftSourceLayout {
     const outline = [];
     const push = (depth, tokens = [], extra = {}) =>
       lines.push({ depth: tokens.length === 0 ? 0 : depth, tokens, ...extra });
-    const section = (key, label, body) => {
-      if (body.length === 0) return;
-      if (outline.length > 0) push(0);
 
-      const id = `source-${key}`;
-      push(1, [code('// MARK: - ', 'mark'), content(label, 'mark')], { heading: 2, id });
-      push(0);
-      body.forEach(([depth, tokens, extra]) => push(1 + depth, tokens, extra));
-      outline.push({ id, label });
-    };
-
-    push(0, [code('//', 'comment')]);
     push(0, [code(`//  ${typeName}.swift`, 'comment')]);
-    push(0, [code('//  CV', 'comment')]);
-    push(0, [code('//', 'comment')]);
     push(0);
     push(0, [code('import ', 'keyword'), code('SwiftUI', 'type')]);
     push(0);
@@ -132,10 +147,23 @@ export class SwiftSourceLayout {
       code('Engineer', 'type'),
       code(' {')
     ]);
+    const body = lines.length;
 
-    section('profile', t('source.marks.profile'), this.profile(data));
-    section('contact', t('source.marks.contact'), this.contact(data));
-    SECTIONS.forEach((key) => section(key, t(`cv:sections.${key}`), this[key](data)));
+    // The name opens the struct, above every MARK, so the first heading a reader meets is the h1.
+    this.identity(data).forEach(([depth, tokens, extra]) => push(1 + depth, tokens, extra));
+
+    SECTIONS.forEach((key) => {
+      const block = this[key](data);
+      if (block.length === 0) return;
+      if (lines.length > body) push(0);
+
+      const id = `source-${key}`;
+      const label = t(LABELS[key] ?? `cv:sections.${key}`);
+      push(1, [code('// MARK: - ', 'mark'), content(label, 'mark')], { heading: 2, id });
+      push(0);
+      block.forEach(([depth, tokens, extra]) => push(1 + depth, tokens, extra));
+      outline.push({ id, label });
+    });
 
     push(0, [code('}')]);
     push(0);
@@ -166,58 +194,60 @@ export class SwiftSourceLayout {
     };
   }
 
-  profile(data) {
-    const string = (name, value, extra = {}) => [
-      ...declaration('let', name),
-      ...quoted(value, extra)
+  identity(data) {
+    const name = clean(data.name);
+    const title = clean(data.title);
+    return [
+      ...(name
+        ? [
+            [
+              0,
+              [...declaration('let', 'name'), ...quoted(name, { element: 'h1' })],
+              { current: true }
+            ]
+          ]
+        : []),
+      ...(title ? [[0, [...declaration('let', 'title'), ...quoted(title)]]] : [])
     ];
-    const [name, title, focus, summary, availability] = [
-      data.name,
-      data.title,
-      data.subtitle,
-      data.profile,
-      data.availability
-    ].map(clean);
+  }
+
+  profile(data) {
+    const [focus, summary, availability] = [data.subtitle, data.profile, data.availability].map(
+      clean
+    );
 
     const lines = [];
-    if (name) lines.push([0, string('name', name, { element: 'h1' }), { current: true }]);
-    if (title) lines.push([0, string('title', title)]);
-    if (focus) lines.push([0, string('focus', focus)]);
+    if (focus) lines.push([0, [...declaration('let', 'focus'), ...quoted(focus)]]);
     if (summary) {
       // A paragraph is a multi-line string in Swift: the delimiters take lines of their own.
       lines.push([0, [...declaration('let', 'summary'), code('"""', 'string')]]);
       lines.push([1, [content(summary, 'string')]]);
       lines.push([1, [code('"""', 'string')]]);
     }
-    if (availability) lines.push([0, string('availability', availability)]);
+    if (availability) {
+      lines.push([0, [...declaration('let', 'availability'), ...quoted(availability)]]);
+    }
     return lines;
   }
 
-  contact(data) {
-    const links = list(data.social)
-      .filter((link) => clean(link.url) !== '')
-      .map((link) => {
-        const address = readableAddress(link.url);
-        return [
-          code('Link', 'call'),
-          code('('),
-          ...quoted(clean(link.platform) || address),
-          code(', '),
-          code('url: ', 'label'),
-          ...quoted(address, { element: 'a', href: clean(link.url) }),
-          code(')')
-        ];
-      });
-
-    return this.call(
-      'Contact',
-      [
-        ['location', data.location],
-        ['email', data.email],
-        ['phone', data.phone],
-        ['links', links]
-      ],
-      { prefix: declaration('let', 'contact'), close: '' }
+  experience(data) {
+    return this.collection(
+      'experience',
+      'Role',
+      list(data.relevant_experience).map((role) =>
+        this.call(
+          'Role',
+          [
+            ['title', role.title, { element: 'h3' }],
+            ['company', role.company],
+            ['location', role.location],
+            ['period', role.period],
+            ['summary', role.summary],
+            ['description', role.description]
+          ],
+          { trailing: list(role.highlights) }
+        )
+      )
     );
   }
 
@@ -257,27 +287,6 @@ export class SwiftSourceLayout {
       ]),
       [0, [code('}')]]
     ];
-  }
-
-  experience(data) {
-    return this.collection(
-      'experience',
-      'Role',
-      list(data.relevant_experience).map((role) =>
-        this.call(
-          'Role',
-          [
-            ['title', role.title, { element: 'h3' }],
-            ['company', role.company],
-            ['location', role.location],
-            ['period', role.period],
-            ['summary', role.summary],
-            ['description', role.description]
-          ],
-          { trailing: list(role.highlights) }
-        )
-      )
-    );
   }
 
   certifications(data) {
@@ -327,7 +336,12 @@ export class SwiftSourceLayout {
       [0, [...declaration('let', 'languages', pairs), code('[')]],
       ...languages.map((language) => [
         1,
-        [...quoted(clean(language.name)), code(': '), ...quoted(clean(language.level)), code(',')]
+        [
+          ...quoted(clean(language.name)),
+          between(': '),
+          ...quoted(clean(language.level)),
+          code(',')
+        ]
       ]),
       [0, [code(']')]]
     ];
@@ -339,6 +353,36 @@ export class SwiftSourceLayout {
     return [
       [0, [...declaration('let', 'interests', arrayOf('String')), ...arrayLiteral(interests)]]
     ];
+  }
+
+  contact(data) {
+    const email = clean(data.email);
+    const phone = clean(data.phone);
+    const links = list(data.social)
+      .filter((link) => clean(link.url) !== '')
+      .map((link) => {
+        const address = readableAddress(link.url);
+        return [
+          code('Link', 'call'),
+          code('('),
+          ...quoted(clean(link.platform) || address),
+          between(', '),
+          code('destination: ', 'label'),
+          ...quoted(address, { element: 'a', href: clean(link.url) }),
+          code(')')
+        ];
+      });
+
+    return this.call(
+      'Contact',
+      [
+        ['location', data.location],
+        ['email', email, email ? { element: 'a', href: `mailto:${email}` } : {}],
+        ['phone', phone, phone ? { element: 'a', href: telephone(phone) } : {}],
+        ['links', links]
+      ],
+      { prefix: declaration('let', 'contact'), close: '' }
+    );
   }
 
   /** `let name: [Type] = [` an entry per block `]`, or nothing when there are no entries. */
@@ -397,7 +441,8 @@ export class SwiftSourceLayout {
   /**
    * The contact card the preview renders: the name, the role, a row of actions and the details.
    * The actions are the ways a card offers to reach someone — call, mail, then the profile's links
-   * — up to one row of four.
+   * — up to one row of four, and each one goes somewhere: a button that does nothing reads as a
+   * broken page.
    */
   card(data, t) {
     const phone = clean(data.phone);
@@ -405,16 +450,50 @@ export class SwiftSourceLayout {
     const location = clean(data.location);
 
     const actions = [
-      ...(phone ? [{ icon: 'phone', label: t('source.card.call') }] : []),
-      ...(email ? [{ icon: 'mail', label: t('source.card.mail') }] : []),
+      ...(phone
+        ? [
+            {
+              icon: 'phone',
+              label: t('source.card.call'),
+              name: t('source.card.callName', { value: phone }),
+              href: telephone(phone)
+            }
+          ]
+        : []),
+      ...(email
+        ? [
+            {
+              icon: 'mail',
+              label: t('source.card.mail'),
+              name: t('source.card.mailName', { value: email }),
+              href: `mailto:${email}`
+            }
+          ]
+        : []),
       ...list(data.social)
         .filter((link) => clean(link.url) !== '' && clean(link.platform) !== '')
-        .map((link) => ({ icon: 'link', label: clean(link.platform) }))
+        .map((link) => ({
+          icon: 'link',
+          label: clean(link.platform),
+          name: clean(link.platform),
+          href: clean(link.url)
+        }))
     ].slice(0, CARD_ACTIONS);
 
     const rows = [
-      ...(phone ? [{ kind: 'phone', label: t('cv:contacts.phone'), value: phone }] : []),
-      ...(email ? [{ kind: 'email', label: t('cv:contacts.email'), value: email }] : []),
+      ...(phone
+        ? [{ kind: 'phone', label: t('cv:contacts.phone'), value: phone, href: telephone(phone) }]
+        : []),
+      ...(email
+        ? [
+            {
+              kind: 'email',
+              label: t('cv:contacts.email'),
+              value: email,
+              href: `mailto:${email}`
+            }
+          ]
+        : []),
       ...(location ? [{ kind: 'location', label: t('source.card.location'), value: location }] : [])
     ];
 

--- a/core/I18nService.js
+++ b/core/I18nService.js
@@ -16,7 +16,7 @@ export class I18nService {
       load: 'languageOnly',
       ns: ['ui', 'cv', 'print'],
       defaultNS: 'ui',
-      backend: { loadPath: 'locales/{{lng}}/{{ns}}.json?v=20260910-xcode1' },
+      backend: { loadPath: 'locales/{{lng}}/{{ns}}.json?v=20260910-xcode2' },
       interpolation: { escapeValue: false }
     });
     return this;

--- a/core/I18nService.js
+++ b/core/I18nService.js
@@ -16,7 +16,7 @@ export class I18nService {
       load: 'languageOnly',
       ns: ['ui', 'cv', 'print'],
       defaultNS: 'ui',
-      backend: { loadPath: 'locales/{{lng}}/{{ns}}.json?v=20260909-nerd1' },
+      backend: { loadPath: 'locales/{{lng}}/{{ns}}.json?v=20260910-xcode1' },
       interpolation: { escapeValue: false }
     });
     return this;

--- a/core/I18nService.js
+++ b/core/I18nService.js
@@ -16,7 +16,7 @@ export class I18nService {
       load: 'languageOnly',
       ns: ['ui', 'cv', 'print'],
       defaultNS: 'ui',
-      backend: { loadPath: 'locales/{{lng}}/{{ns}}.json?v=20260910-xcode2' },
+      backend: { loadPath: 'locales/{{lng}}/{{ns}}.json?v=20260911-xcode3' },
       interpolation: { escapeValue: false }
     });
     return this;

--- a/design-glacier.css
+++ b/design-glacier.css
@@ -49,8 +49,8 @@ body[data-layout='technical'] .hero-section {
   border-bottom: 3px solid var(--signal-bright);
 }
 
-/* Nerd Mode is not in this list: it carries no masthead of its own — no ground, no rule, no
-   border — and dresses itself entirely in its own block at the foot of this file. */
+/* Nerd Mode is not in this list: on screen its masthead gives way to the editor, and it dresses
+   itself entirely in its own block at the foot of this file. */
 
 /* The decorative white blob in the corner was the only "dynamism" the hero had.
    A hard-edged mark reads as a decision; a soft glow reads as a default. */
@@ -1296,754 +1296,542 @@ body[data-layout='technical'] .hero-name {
 }
 
 /* =============================================================================
-   Nerd Mode — the skin. "Graphite".
-   The arrangement (the 178pt rail, the masthead grid, the credentials band) is in layouts.css.
-   This block dresses it, and it deliberately overrides the shared rules earlier in this file —
-   the serif name, the signal-blue rule under the section labels, the teal link colour — which
-   no longer name `nerd` in their selectors but still reach it through their bare-class halves.
+   Nerd Mode — the skin. "Source".
+   The arrangement — the toolbar, the three panes, the line geometry, the phone — is in
+   layouts.css. This block dresses it as a dark editor with Swift syntax colouring.
 
-   The direction: one sheet of anthracite, edge to edge, and nothing lifted off it. No card, no
-   panel, no gradient, no second surface — structure is drawn with hairlines and with a fixed
-   monospace column, never with a fill. The page is achromatic except in one place.
+   Colour has a role, and every text tone is measured against the editor's #14161A rather than
+   estimated. The neutrals are the ones this layout already had: `--x-ink` #ECEEF1 (15.6:1) the
+   name, the roles and the section labels, `--x-body` #B9C0C9 (9.9:1) punctuation and brackets,
+   `--x-muted` #9AA3AE (7.1:1) the chrome's labels, `--x-dim` #7D8792 (5.0:1) the line
+   numbers — the floor: nothing below it carries a character. The grounds step up from the editor:
+   #17191E the panes, #1C1F25 the chrome, #262A31 a selected row, #1B1F25 the line the editor opens
+   on; #282D35 and #3A3F47 are hairlines and hardware and never text.
 
-   Colour has a role, and every text tone is measured against #14161A rather than estimated:
-   `--g-ink` #ECEEF1 (15.6:1) names and titles, `--g-body` #B9C0C9 (9.9:1) every sentence,
-   `--g-muted` #9AA3AE (7.1:1) summaries and the contact rail, `--g-dim` #7D8792 (5.0:1) dates,
-   small labels and separators — and #7D8792 is the floor: nothing below it may carry a word,
-   including a separator glyph and a 10px label. `--g-rule` #282D35 and `--g-rule-soft` #1F242B
-   are hairlines and never text. `--g-signal` #C8F169 (14.0:1) marks the present tense and only
-   that: the role line, the section index, the current role's tick and employer, the skill
-   category labels, and the download button's border. A seventh use would make it decoration.
+   The syntax colours sit in a narrow band of OKLCH lightness, 0.74 to 0.85, and differ by hue, so
+   no role shouts over another; each clears 7:1 on the editor and on the current line. `--x-string`
+   #F8BBA0 (10.9:1) is the CV itself — every literal is the profile's own words, so the colour a
+   reader spends longest in is the calmest. `--x-keyword` #F197C2 (8.6:1) `let`, `var`, `some`,
+   `struct`; `--x-type` #C7AFF5 (9.4:1) the types; `--x-call` #76D3B4 (10.1:1) an initialiser or a
+   method being called; `--x-property` #69CEE6 (10.0:1) the stored properties; `--x-label` #A8BEEC
+   (9.7:1) an argument label; `--x-number` #E2CE80 (11.5:1) a number the data wrote as one;
+   `--x-comment` #9CB19F (7.9:1) the comments and the MARK prefix. Brackets and commas stay in
+   `--x-body`: they are the structure, and a coloured bracket is noise. `--x-signal` #C8F169
+   (14.0:1), the lime this layout already spent on the present tense, marks the open tab,
+   `#Preview` and the download button, and nothing else.
+
+   The phone pictures an app, not an editor, so it has a small palette of its own: a #0E0F12
+   ground, grouped cells of #1D1F24 divided by #2C2F36, `--x-app-ink` #F3F4F6 (15.0:1 on a cell),
+   `--x-app-muted` #9FA5AC (6.6:1) the labels, and one tint — the property cyan, 9.1:1 on a cell —
+   on the actions and the addresses, where an app puts its tint. The portrait, a cut-out, sits on
+   a pale backdrop of its own.
+
+   The code is set in JetBrains Mono from Google Fonts, with the platform's monospace behind it and
+   ligatures off, so every character on a line is the character it is. The chrome is set in Inter,
+   like the other two layouts.
 
    Screen-only, like the arrangement and like the other two skins: on paper print.css prints the
    base DOM in ink on white, and a dark page that printed dark would be a defect.
    ========================================================================================== */
 @media screen {
   body[data-layout='nerd'] {
-    --g-bg: #14161a;
-    --g-ink: #eceef1;
-    --g-body: #b9c0c9;
-    --g-muted: #9aa3ae;
-    --g-dim: #7d8792;
-    --g-signal: #c8f169;
-    --g-rule: #282d35;
-    --g-rule-soft: #1f242b;
-    --g-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    --x-bg: #14161a;
+    --x-pane: #17191e;
+    --x-chrome: #1c1f25;
+    --x-raised: #262a31;
+    --x-current: #1b1f25;
+    --x-rule: #282d35;
+    --x-rim: #3a3f47;
+    --x-device: #0b0c0f;
+    --x-ink: #eceef1;
+    --x-body: #b9c0c9;
+    --x-muted: #9aa3ae;
+    --x-dim: #7d8792;
+    --x-signal: #c8f169;
+    --x-string: #f8bba0;
+    --x-keyword: #f197c2;
+    --x-type: #c7aff5;
+    --x-property: #69cee6;
+    --x-number: #e2ce80;
+    --x-comment: #9cb19f;
+    --x-call: #76d3b4;
+    --x-label: #a8beec;
+    --x-app-ground: #0e0f12;
+    --x-app-cell: #1d1f24;
+    --x-app-rule: #2c2f36;
+    --x-app-ink: #f3f4f6;
+    --x-app-muted: #9fa5ac;
+    --x-portrait-light: #f3f4f6;
+    --x-portrait-shade: #c3c9d1;
+    --x-tint: var(--x-property);
+    --x-mono: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+    --x-sans: 'Inter', system-ui, -apple-system, 'Segoe UI', sans-serif;
 
-    /* The shared tokens are remapped rather than fought: every base rule that reaches for a
-       border, a muted text or a secondary ground now lands inside this palette. */
-    --text-primary: var(--g-ink);
-    --text-secondary: var(--g-body);
-    --text-muted: var(--g-muted);
-    --text-light: var(--g-dim);
-    --text-white: var(--g-ink);
-    --primary-color: var(--g-ink);
-    --primary-dark: var(--g-ink);
-    --primary-light: var(--g-rule);
-    --accent-color: var(--g-signal);
-    --accent-light: var(--g-signal);
-    --border-color: var(--g-rule);
-    --border-light: var(--g-rule-soft);
-    --bg-primary: var(--g-bg);
-    --bg-secondary: transparent;
-    --bg-accent: transparent;
+    /* The shared tokens are remapped rather than fought, for the one base surface still on show —
+       the footer. */
+    --text-primary: var(--x-ink);
+    --text-secondary: var(--x-body);
+    --text-muted: var(--x-muted);
+    --text-light: var(--x-dim);
+    --border-color: var(--x-rule);
+    --bg-primary: var(--x-chrome);
 
-    background: var(--g-bg);
-    color: var(--g-body);
+    background: var(--x-bg);
+    color: var(--x-body);
+    font-family: var(--x-sans);
   }
 
   body[data-layout='nerd'] .container {
-    background: var(--g-bg);
+    background: var(--x-chrome);
   }
 
-  /* --- The top strip ------------------------------------------------------------------------ */
+  /* --- The toolbar ---------------------------------------------------------------------------- */
   body[data-layout='nerd'] .layout-switcher {
     border: 0;
-    border-bottom: 1px solid var(--g-rule);
+    border-bottom: 1px solid var(--x-rule);
     border-radius: 0;
-    background: transparent;
+    background: var(--x-chrome);
     box-shadow: none;
+  }
+
+  /* The window's dots are grey, not red, amber and green: they close nothing, and a control that
+     looks live and does nothing reads as broken. */
+  body[data-layout='nerd'] .layout-switcher::before {
+    background: var(--x-rim);
+    box-shadow:
+      20px 0 0 var(--x-rim),
+      40px 0 0 var(--x-rim);
   }
 
   body[data-layout='nerd'] .layout-switcher a {
+    border: 1px solid var(--x-rule);
     border-radius: 0;
-    color: var(--g-dim);
-    font-family: var(--g-mono);
-    font-size: 10.5px;
-    font-weight: 400;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
+    background: var(--x-bg);
+    color: var(--x-muted);
+    font-family: var(--x-sans);
+    font-size: 12px;
+    font-weight: 500;
+    line-height: 1.4;
+    letter-spacing: 0;
+    text-transform: none;
+  }
+
+  body[data-layout='nerd'] .layout-switcher a:first-child {
+    border-radius: 7px 0 0 7px;
+  }
+
+  body[data-layout='nerd'] .layout-switcher a:last-child {
+    border-radius: 0 7px 7px 0;
   }
 
   body[data-layout='nerd'] .layout-switcher a:hover {
-    color: var(--g-body);
+    color: var(--x-ink);
   }
 
   body[data-layout='nerd'] .layout-switcher a[aria-current='page'] {
-    background: transparent;
-    color: var(--g-signal);
+    position: relative;
+    border-color: var(--x-rim);
+    background: var(--x-raised);
+    color: var(--x-ink);
   }
 
-  /* --- The masthead ------------------------------------------------------------------------- */
-  /* No ground and no border: the name sits on the same anthracite as the rest of the page, and
-     one hairline over the contact rail is all that separates the masthead from what follows. */
-  body[data-layout='nerd'] .hero-section {
-    background: transparent;
-    border: 0;
-    color: var(--g-body);
-  }
-
-  body[data-layout='nerd'] .hero-section::before {
-    content: none;
-  }
-
-  body[data-layout='nerd'] .hero-name {
-    margin: 0;
-    font-family: 'Inter', system-ui, sans-serif;
-    font-size: 58px;
-    font-weight: 700;
-    line-height: 1.02;
-    letter-spacing: -0.035em;
-    color: var(--g-ink);
-  }
-
-  /* The role line is the present tense, so it carries the signal. It keeps the case the data
-     wrote: "Senior iOS Engineer" must not reach an iOS hiring manager as "SENIOR IOS ENGINEER". */
-  body[data-layout='nerd'] .hero-title {
-    margin: 16px 0 0;
-    font-family: var(--g-mono);
+  /* --- The navigator -------------------------------------------------------------------------- */
+  body[data-layout='nerd'] .source-navigator {
+    border-right: 1px solid var(--x-rule);
+    background: var(--x-pane);
     font-size: 12.5px;
-    font-weight: 500;
-    line-height: 1.7;
-    letter-spacing: 0.2em;
-    text-transform: none;
-    color: var(--g-signal);
+    line-height: 1.3;
   }
 
-  body[data-layout='nerd'] .hero-subtitle {
-    margin: 14px 0 0;
-    font-family: var(--g-mono);
-    font-size: 11.5px;
-    font-weight: 400;
-    letter-spacing: 0.04em;
-    color: var(--g-muted);
+  body[data-layout='nerd'] .source-navigator-file {
+    border-radius: 5px;
+    background: var(--x-raised);
+    color: var(--x-ink);
   }
 
-  body[data-layout='nerd'] .hero-summary {
-    margin: 26px 0 0;
-    max-width: 74ch;
-    font-size: 15.5px;
-    line-height: 1.68;
-    color: var(--g-body);
-  }
-
-  /* Work authorisation is the first thing a German recruiter checks on a foreign CV; here it is
-     a fact in the metadata voice, not a badge — this layout has no shapes to put it in. */
-  body[data-layout='nerd'] .hero-availability {
-    margin: 22px 0 0;
-    font-family: var(--g-mono);
-    font-size: 11px;
-    line-height: 1.6;
-    letter-spacing: 0.04em;
-    color: var(--g-dim);
-  }
-
-  body[data-layout='nerd'] .hero-availability[hidden] {
-    display: none;
-  }
-
-  /* The portrait is a fact about the applicant, not the hero of the page: square, desaturated,
-     held by a hairline. Grayscale also keeps the promise that one colour appears on this page. */
-  body[data-layout='nerd'] .profile-image-wrapper img {
-    width: 104px;
-    height: 104px;
-    border: 1px solid var(--g-rule);
-    border-radius: 0;
-    box-shadow: none;
-    filter: grayscale(1) contrast(1.06) brightness(0.94);
-  }
-
-  /* The contact rail: one hairline above it, monospace across it, the addresses divided from the
-     location by a rule rather than by a glyph this DOM does not have. */
-  body[data-layout='nerd'] .contact-card {
-    padding: 18px 0 0;
-    border: 0;
-    border-top: 1px solid var(--g-rule);
-    border-radius: 0;
-    background: transparent;
-    backdrop-filter: none;
-    color: var(--g-muted);
-    text-align: left;
-  }
-
-  /* A colour emoji would be the second chromatic thing on the page, and it says nothing the
-     address beside it does not. The location text is untouched. */
-  body[data-layout='nerd'] .contact-icon {
-    display: none;
-  }
-
-  body[data-layout='nerd'] .contact-item,
-  body[data-layout='nerd'] .contact-details,
-  body[data-layout='nerd'] .social-links a {
-    font-family: var(--g-mono);
-    font-size: 11.5px;
-    line-height: 1.7;
-    letter-spacing: 0.04em;
-    color: var(--g-muted);
-  }
-
-  body[data-layout='nerd'] .contact-details {
-    padding-left: 22px;
-    border-left: 1px solid var(--g-rule);
-  }
-
-  body[data-layout='nerd'] .contact-details strong {
-    font-weight: 500;
-    color: var(--g-dim);
-  }
-
-  /* Three readable addresses and two separators need a line of their own: a rail that wraps by
-     accident reads as a mistake. */
-  body[data-layout='nerd'] .social-links {
-    flex-basis: 100%;
-    justify-content: flex-start;
-    margin-top: 2px;
-  }
-
-  body[data-layout='nerd'] .contact-card a,
-  body[data-layout='nerd'] .social-links a {
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-    background: transparent;
-    color: var(--g-body);
-    font-weight: 400;
-    text-decoration: none;
-    box-shadow: none;
-  }
-
-  body[data-layout='nerd'] .contact-card a:hover,
-  body[data-layout='nerd'] .social-links a:hover {
-    background: transparent;
-    color: var(--g-signal);
-    text-decoration: underline;
-    text-underline-offset: 3px;
-    transform: none;
-  }
-
-  body[data-layout='nerd'] .inline-separator {
-    padding: 0 10px;
-    color: var(--g-dim);
-  }
-
-  /* --- The section heads --------------------------------------------------------------------- */
-  body[data-layout='nerd'] .spotlight-title,
-  body[data-layout='nerd'] .section-title {
-    border: 0;
-    text-align: left;
-  }
-
-  body[data-layout='nerd'] .spotlight-title::before,
-  body[data-layout='nerd'] .section-title::before {
-    font-family: var(--g-mono);
-    font-size: 11px;
-    font-weight: 500;
-    letter-spacing: 0.1em;
-    color: var(--g-signal);
-  }
-
-  body[data-layout='nerd'] .spotlight-title::after,
-  body[data-layout='nerd'] .section-title::after {
-    background: var(--g-rule);
-  }
-
-  body[data-layout='nerd'] .spotlight-title,
-  body[data-layout='nerd'] .section-title span:last-child {
-    font-family: var(--g-mono);
-    font-size: 11px;
-    font-weight: 500;
-    letter-spacing: 0.22em;
-    text-transform: uppercase;
-    color: var(--g-ink);
-  }
-
-  /* The four short sections at the foot of the page are columns of one band, so their heads are
-     column labels: the same number, word and rule, one step quieter. */
-  body[data-layout='nerd'] .certifications-section .section-title,
-  body[data-layout='nerd'] .education-section .section-title,
-  body[data-layout='nerd'] .languages-section .section-title,
-  body[data-layout='nerd'] .interests-section .section-title {
-    gap: 10px;
-    margin-bottom: 16px;
-  }
-
-  body[data-layout='nerd'] .certifications-section .section-title::before,
-  body[data-layout='nerd'] .education-section .section-title::before,
-  body[data-layout='nerd'] .languages-section .section-title::before,
-  body[data-layout='nerd'] .interests-section .section-title::before {
-    font-size: 10px;
-  }
-
-  body[data-layout='nerd'] .certifications-section .section-title span:last-child,
-  body[data-layout='nerd'] .education-section .section-title span:last-child,
-  body[data-layout='nerd'] .languages-section .section-title span:last-child,
-  body[data-layout='nerd'] .interests-section .section-title span:last-child {
-    font-size: 10px;
-    letter-spacing: 0.18em;
-    color: var(--g-dim);
-  }
-
-  body[data-layout='nerd'] .certifications-section .section-title::after,
-  body[data-layout='nerd'] .education-section .section-title::after,
-  body[data-layout='nerd'] .languages-section .section-title::after,
-  body[data-layout='nerd'] .interests-section .section-title::after {
-    background: var(--g-rule-soft);
-  }
-
-  /* --- 01 The skills table -------------------------------------------------------------------- */
-  body[data-layout='nerd'] .skills-spotlight {
-    background: transparent;
-    border: 0;
-  }
-
-  body[data-layout='nerd'] .skills-showcase {
-    border-top: 1px solid var(--g-rule-soft);
-  }
-
-  body[data-layout='nerd'] .skill-group {
-    border-bottom: 1px solid var(--g-rule-soft);
-  }
-
-  /* The category holds the rail. It keeps the case the data wrote — "iOS" must never be
-     uppercased into "IOS" — so the monospace, the tracking and the signal do the work that
-     uppercasing would have done. */
-  body[data-layout='nerd'] .skill-category {
-    padding-top: 3px;
-    font-family: var(--g-mono);
-    font-size: 11px;
-    font-weight: 500;
-    line-height: 1.6;
-    letter-spacing: 0.14em;
-    text-transform: none;
-    color: var(--g-signal);
-  }
-
-  body[data-layout='nerd'] .skill-list {
-    font-size: 14px;
-    line-height: 1.75;
-    color: var(--g-ink);
-  }
-
-  /* --- 02 The experience ---------------------------------------------------------------------- */
-  body[data-layout='nerd'] .job-entry {
-    background: transparent;
-  }
-
-  body[data-layout='nerd'] .job-entry + .job-entry {
-    border-top: 1px solid var(--g-rule-soft);
-  }
-
-  /* A document does not react to the pointer: the base lift is off. */
-  body[data-layout='nerd'] .job-entry:hover {
-    border-left-color: transparent;
-    box-shadow: none;
-    transform: none;
-  }
-
-  /* The dates hold the rail so the career can be scanned vertically without reading a word.
-     Tabular figures keep the years in the same place from role to role. */
-  body[data-layout='nerd'] .job-period {
-    margin: 0;
-    font-family: var(--g-mono);
-    font-size: 11.5px;
-    font-weight: 400;
-    line-height: 1.7;
-    letter-spacing: 0.06em;
-    font-variant-numeric: tabular-nums;
-    color: var(--g-body);
-  }
-
-  /* The signal tick: the one mark that says which of these three is now, and it appears nowhere
-     else on the page. */
-  body[data-layout='nerd'] .experience-content > .job-entry:first-child .job-period {
-    color: var(--g-ink);
-  }
-
-  body[data-layout='nerd'] .experience-content > .job-entry:first-child .job-period::before {
+  /* The disclosure chevron and the file glyph are pictures, so the file's name stays the only text
+     in the row. */
+  body[data-layout='nerd'] .source-navigator-file::before,
+  body[data-layout='nerd'] [data-source-file]::before {
     content: '';
-    display: block;
-    width: 22px;
-    height: 2px;
-    margin-bottom: 14px;
-    background: var(--g-signal);
+    flex: none;
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: contain;
   }
 
-  body[data-layout='nerd'] .job-header {
-    margin: 0;
-    font-family: var(--g-mono);
-    font-size: 11.5px;
-    line-height: 1.7;
-    letter-spacing: 0.04em;
-    color: var(--g-dim);
+  body[data-layout='nerd'] .source-navigator-file::before {
+    width: 10px;
+    height: 10px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 10 10' fill='none' stroke='%237d8792' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M2.5 3.75 5 6.25l2.5-2.5'/%3E%3C/svg%3E");
   }
 
-  /* The title takes its own line; the employer and the place follow it in the metadata voice. */
-  body[data-layout='nerd'] .job-title {
-    display: block;
-    margin-bottom: 7px;
-    font-family: 'Inter', system-ui, sans-serif;
-    font-size: 19px;
-    font-weight: 600;
-    line-height: 1.35;
-    letter-spacing: -0.012em;
-    color: var(--g-ink);
+  body[data-layout='nerd'] [data-source-file]::before {
+    width: 14px;
+    height: 14px;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23f8bba0' stroke-width='1.4' stroke-linejoin='round'%3E%3Cpath d='M4 1.75h5.25L12.5 5v9.25H4z'/%3E%3Cpath d='M9 1.75V5.25h3.5'/%3E%3C/svg%3E");
   }
 
-  body[data-layout='nerd'] .job-company {
-    font-family: 'Inter', system-ui, sans-serif;
-    font-size: 14px;
-    font-weight: 500;
-    letter-spacing: 0;
-    color: var(--g-body);
-  }
-
-  body[data-layout='nerd'] .experience-content > .job-entry:first-child .job-company {
-    color: var(--g-signal);
-  }
-
-  body[data-layout='nerd'] .job-summary {
-    margin: 12px 0 0;
-    max-width: 74ch;
-    font-size: 13.5px;
-    font-weight: 400;
-    line-height: 1.68;
-    color: var(--g-muted);
-  }
-
-  body[data-layout='nerd'] .job-description {
-    margin: 12px 0 0;
-    max-width: 74ch;
-    font-size: 14.5px;
-    line-height: 1.68;
-    color: var(--g-body);
-  }
-
-  /* An em dash instead of a disc, drawn as a list marker rather than as generated content: a
-     marker is not part of the text a reader copies, and the achievements come out of the page
-     as the data wrote them. */
-  body[data-layout='nerd'] .job-highlights {
-    list-style: '—';
-    padding-left: 18px;
-    color: var(--g-body);
-  }
-
-  body[data-layout='nerd'] .job-highlights li {
-    margin-bottom: 11px;
-    max-width: 74ch;
-    font-size: 14.5px;
-    line-height: 1.68;
-  }
-
-  body[data-layout='nerd'] .job-highlights li:last-child {
-    margin-bottom: 0;
-  }
-
-  /* The no-break space is the marker's gutter: `::marker` takes no width or padding, and a
-     plain space after the dash would be collapsed away. */
-  body[data-layout='nerd'] .job-highlights li::marker {
-    content: '—\00a0';
-    font-family: var(--g-mono);
-    font-size: 13px;
-    color: var(--g-dim);
-  }
-
-  /* --- 03-06 The credentials band --------------------------------------------------------------- */
-  /* Four columns of one band, divided by vertical hairlines and closed by a horizontal one top
-     and bottom. Nothing in it is a card. */
-  body[data-layout='nerd'] .certifications-section,
-  body[data-layout='nerd'] .education-section,
-  body[data-layout='nerd'] .languages-section,
-  body[data-layout='nerd'] .interests-section {
-    border-top: 1px solid var(--g-rule);
-    border-bottom: 1px solid var(--g-rule);
-  }
-
-  body[data-layout='nerd'] .certifications-section,
-  body[data-layout='nerd'] .education-section,
-  body[data-layout='nerd'] .languages-section {
-    border-right: 1px solid var(--g-rule-soft);
-  }
-
-  /* The certification: its name in the page's voice, the issuer and the year in the metadata
-     voice. The signal stays out of it — it belongs to the present tense, and a 2024 award is
-     evidence, not now. */
-  body[data-layout='nerd'] .certifications-list li {
-    background: transparent;
-    font-family: var(--g-mono);
-    font-size: 10.5px;
-    line-height: 1.7;
-    letter-spacing: 0.04em;
-    color: var(--g-muted);
-  }
-
-  body[data-layout='nerd'] .certifications-list strong {
-    display: block;
-    font-family: 'Inter', system-ui, sans-serif;
-    font-size: 14px;
-    font-weight: 600;
-    line-height: 1.4;
-    letter-spacing: 0;
-    color: var(--g-ink);
-  }
-
-  body[data-layout='nerd'] .certifications-list a {
-    color: inherit;
+  body[data-layout='nerd'] .source-outline a {
+    gap: 9px;
+    border-radius: 5px;
+    color: var(--x-body);
     text-decoration: none;
   }
 
-  body[data-layout='nerd'] .certifications-list a:hover strong {
-    color: var(--g-signal);
+  body[data-layout='nerd'] .source-outline a::before {
+    content: '';
+    flex: none;
+    width: 5px;
+    height: 5px;
+    border-radius: 50%;
+    background: var(--x-comment);
   }
 
-  body[data-layout='nerd'] .cert-description {
-    margin-top: 10px;
-    font-family: 'Inter', system-ui, sans-serif;
-    font-size: 12.5px;
-    letter-spacing: 0;
-    line-height: 1.6;
-    color: var(--g-muted);
+  body[data-layout='nerd'] .source-outline a:hover {
+    background: var(--x-chrome);
+    color: var(--x-ink);
   }
 
-  body[data-layout='nerd'] .edu-entry {
-    background: transparent;
+  /* --- The editor ----------------------------------------------------------------------------- */
+  body[data-layout='nerd'] .source-editor {
+    border-right: 1px solid var(--x-rule);
+    background: var(--x-bg);
   }
 
-  body[data-layout='nerd'] .edu-entry:hover {
-    border-color: transparent;
-    box-shadow: none;
+  body[data-layout='nerd'] .source-tabs {
+    border-bottom: 1px solid var(--x-rule);
+    background: var(--x-chrome);
   }
 
-  body[data-layout='nerd'] .edu-degree {
-    margin: 0 0 5px;
+  /* The open tab joins the editor below it; the lime along its top edge is the one mark of which
+     file is open. */
+  body[data-layout='nerd'] .source-tab {
+    border-right: 1px solid var(--x-rule);
+    background: var(--x-bg);
+    box-shadow: inset 0 2px 0 var(--x-signal);
+    color: var(--x-ink);
+    font-size: 12px;
+  }
+
+  body[data-layout='nerd'] .source-code {
+    color: var(--x-body);
+    font-family: var(--x-mono);
     font-size: 13.5px;
+    font-variant-ligatures: none;
+    line-height: var(--x-line);
+  }
+
+  /* The line the editor opens on: the name. */
+  body[data-layout='nerd'] .source-line.is-current {
+    background: var(--x-current);
+  }
+
+  body[data-layout='nerd'] .source-number {
+    color: var(--x-dim);
+    font-size: 12px;
+  }
+
+  body[data-layout='nerd'] .is-current .source-number {
+    color: var(--x-ink);
+  }
+
+  /* The headings keep the code's size and face; weight and ink carry the hierarchy. */
+  body[data-layout='nerd'] .source-line h1,
+  body[data-layout='nerd'] h2.source-line,
+  body[data-layout='nerd'] .source-line h3 {
+    font: inherit;
+    letter-spacing: 0;
+    text-transform: none;
+  }
+
+  body[data-layout='nerd'] .tok-plain {
+    color: var(--x-body);
+  }
+
+  body[data-layout='nerd'] .tok-label {
+    color: var(--x-label);
+  }
+
+  body[data-layout='nerd'] .tok-call {
+    color: var(--x-call);
+  }
+
+  body[data-layout='nerd'] .tok-keyword {
+    color: var(--x-keyword);
     font-weight: 600;
-    line-height: 1.4;
-    color: var(--g-ink);
   }
 
-  body[data-layout='nerd'] .edu-school,
-  body[data-layout='nerd'] .edu-period {
-    font-family: var(--g-mono);
-    font-size: 10.5px;
-    font-weight: 400;
-    line-height: 1.7;
-    letter-spacing: 0.04em;
-    color: var(--g-muted);
+  body[data-layout='nerd'] .tok-type {
+    color: var(--x-type);
   }
 
-  body[data-layout='nerd'] .edu-description {
-    margin-top: 8px;
-    font-size: 12.5px;
-    line-height: 1.6;
-    color: var(--g-muted);
+  body[data-layout='nerd'] .tok-property {
+    color: var(--x-property);
   }
 
-  /* A language is a name and a CEFR level, both as text: no dot, no bar, nothing to decode. */
-  body[data-layout='nerd'] .languages-list li {
-    font-family: var(--g-mono);
-    font-size: 10.5px;
-    line-height: 1.7;
-    letter-spacing: 0.04em;
-    color: var(--g-muted);
+  body[data-layout='nerd'] .tok-string {
+    color: var(--x-string);
   }
 
-  body[data-layout='nerd'] .languages-list strong {
-    display: block;
-    font-family: 'Inter', system-ui, sans-serif;
-    font-size: 13.5px;
+  body[data-layout='nerd'] .tok-number {
+    color: var(--x-number);
+  }
+
+  body[data-layout='nerd'] .tok-comment {
+    color: var(--x-comment);
+  }
+
+  body[data-layout='nerd'] .tok-macro {
+    color: var(--x-signal);
     font-weight: 600;
-    letter-spacing: 0;
-    color: var(--g-ink);
   }
 
-  body[data-layout='nerd'] .interests-line {
-    font-size: 13.5px;
-    line-height: 1.9;
-    color: var(--g-body);
+  /* A MARK is a section heading: the prefix in the comment's colour, the label in ink, both bold. */
+  body[data-layout='nerd'] .tok-mark {
+    color: var(--x-comment);
+    font-weight: 700;
   }
 
-  /* --- The separators -------------------------------------------------------------------------- */
-  /* The renderers emit one element per name with a real separator text node between them, and
-     that text node is what a parser, a screen reader and the clipboard read: `#skills` still says
-     "Swift, SwiftUI, UIKit", and a selection of the list still comes out comma-separated —
-     measured, not assumed. The comma is set at zero size and a dim slash is drawn in its place,
-     so the page reads as a slash-separated list while the document still reads as a comma-
-     separated one. Print keeps the commas: this is inside @media screen.
-
-     The slash is drawn by ::before and not ::after on purpose. The separator's own text is
-     ", " — a comma and a space — and that space is the only place the line may break. Drawn
-     after it, the slash was pushed onto the next line and eleven of them began a line; drawn
-     before it, the slash stays welded to the name it follows and the break falls after it. */
-  body[data-layout='nerd'] .skill-sep,
-  body[data-layout='nerd'] .interest-sep {
-    font-size: 0;
-    letter-spacing: 0;
+  body[data-layout='nerd'] .tok-mark:not([data-code]) {
+    color: var(--x-ink);
   }
 
-  body[data-layout='nerd'] .skill-sep::before,
-  body[data-layout='nerd'] .interest-sep::before {
-    content: '/';
-    font-family: var(--g-mono);
-    font-size: 12.5px;
-    font-weight: 400;
-    color: var(--g-dim);
-    padding: 0 0.42em;
+  /* The name and each role's title are the strings a recruiter scans for, so they step up to ink
+     and bold. Everything else a string holds stays in the string's colour. */
+  body[data-layout='nerd'] h1.tok-string,
+  body[data-layout='nerd'] h3.tok-string {
+    color: var(--x-ink);
+    font-weight: 700;
   }
 
-  /* --- The footer and focus ---------------------------------------------------------------------- */
+  /* A link sits in a string, so colour cannot be what marks it: it is underlined. */
+  body[data-layout='nerd'] .source-code a {
+    text-decoration: underline;
+    text-decoration-color: var(--x-rim);
+    text-underline-offset: 3px;
+  }
+
+  body[data-layout='nerd'] .source-code a:hover {
+    color: var(--x-signal);
+    text-decoration-color: currentColor;
+  }
+
+  /* --- The preview ---------------------------------------------------------------------------- */
+  body[data-layout='nerd'] .source-preview {
+    background: var(--x-pane);
+  }
+
+  body[data-layout='nerd'] .source-preview-bar {
+    border-bottom: 1px solid var(--x-rule);
+    background: var(--x-chrome);
+    font-size: 12px;
+  }
+
+  body[data-layout='nerd'] .source-preview-bar span:first-child {
+    color: var(--x-muted);
+    font-weight: 500;
+  }
+
+  body[data-layout='nerd'] .source-preview-bar span:last-child {
+    color: var(--x-dim);
+  }
+
+  body[data-layout='nerd'] .simulator {
+    border: 1px solid var(--x-rim);
+    background: var(--x-device);
+    box-shadow:
+      0 0 0 1px var(--x-device),
+      0 30px 60px -20px rgb(0 0 0 / 0.7);
+  }
+
+  body[data-layout='nerd'] .simulator::after {
+    background: var(--x-rim);
+  }
+
+  /* One strip, three keys: the action button and the two volume keys are cut out of it. */
+  body[data-layout='nerd'] .simulator::before {
+    background: linear-gradient(
+      to bottom,
+      var(--x-rim) 0 17%,
+      transparent 17% 31%,
+      var(--x-rim) 31% 62%,
+      transparent 62% 69%,
+      var(--x-rim) 69% 100%
+    );
+  }
+
+  body[data-layout='nerd'] .simulator-screen {
+    background: var(--x-app-ground);
+  }
+
+  /* --- The contact card ----------------------------------------------------------------------- */
+  /* The portrait is a cut-out on a transparent ground. On the app's near-black it floated, and the
+     edge of its mask showed; a contact photo has a ground of its own, so the circle gets a pale
+     studio backdrop for the cut-out to sit in. */
+  body[data-layout='nerd'] .simulator-portrait {
+    background: radial-gradient(
+      circle at 50% 38%,
+      var(--x-portrait-light),
+      var(--x-portrait-shade)
+    );
+    box-shadow: 0 0 0 0.6cqw var(--x-app-rule);
+  }
+
+  body[data-layout='nerd'] .app-card {
+    color: var(--x-app-ink);
+    font-family: var(--x-sans);
+    line-height: 1.3;
+  }
+
+  body[data-layout='nerd'] .app-name {
+    font-size: 8.2cqw;
+    font-weight: 600;
+    line-height: 1.15;
+    letter-spacing: -0.02em;
+  }
+
+  body[data-layout='nerd'] .app-title {
+    color: var(--x-app-muted);
+    font-size: 3.9cqw;
+    line-height: 1.35;
+  }
+
+  body[data-layout='nerd'] .app-action {
+    background: var(--x-app-cell);
+    color: var(--x-tint);
+    font-size: 3cqw;
+    font-weight: 500;
+  }
+
+  /* The glyphs are masks filled with the text colour, so the tint lives in one token. */
+  body[data-layout='nerd'] .app-action::before {
+    background: currentColor;
+    -webkit-mask: var(--x-icon) center / contain no-repeat;
+    mask: var(--x-icon) center / contain no-repeat;
+  }
+
+  body[data-layout='nerd'] .app-action[data-icon='phone'] {
+    --x-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='1.4' stroke-linejoin='round'%3E%3Cpath d='M4.2 2.5h2.1l1.1 2.9-1.4 1.1a7.6 7.6 0 0 0 3.5 3.5l1.1-1.4 2.9 1.1v2.1a1.3 1.3 0 0 1-1.4 1.3A11 11 0 0 1 2.9 3.9a1.3 1.3 0 0 1 1.3-1.4z'/%3E%3C/svg%3E");
+  }
+
+  body[data-layout='nerd'] .app-action[data-icon='mail'] {
+    --x-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Crect x='2' y='3.5' width='12' height='9' rx='1.5'/%3E%3Cpath d='m2.5 4.5 5.5 4.2 5.5-4.2'/%3E%3C/svg%3E");
+  }
+
+  body[data-layout='nerd'] .app-action[data-icon='link'] {
+    --x-icon: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 16 16' fill='none' stroke='%23000' stroke-width='1.4' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M6.8 9.2a2.6 2.6 0 0 0 3.7 0l2.2-2.2a2.6 2.6 0 0 0-3.7-3.7l-.9.9'/%3E%3Cpath d='M9.2 6.8a2.6 2.6 0 0 0-3.7 0L3.3 9a2.6 2.6 0 0 0 3.7 3.7l.9-.9'/%3E%3C/svg%3E");
+  }
+
+  body[data-layout='nerd'] .app-rows {
+    background: var(--x-app-cell);
+  }
+
+  body[data-layout='nerd'] .app-row + .app-row {
+    border-top: 1px solid var(--x-app-rule);
+  }
+
+  body[data-layout='nerd'] .app-row-label {
+    color: var(--x-app-muted);
+    font-size: 3cqw;
+  }
+
+  body[data-layout='nerd'] .app-row-value {
+    color: var(--x-app-ink);
+    font-size: 4cqw;
+  }
+
+  /* A number and an address are what an app tints: they are where a tap would go. */
+  body[data-layout='nerd'] .app-row[data-kind='phone'] .app-row-value,
+  body[data-layout='nerd'] .app-row[data-kind='email'] .app-row-value {
+    color: var(--x-tint);
+  }
+
+  body[data-layout='nerd'] .simulator-screen::after {
+    background: var(--x-device);
+  }
+
+  /* --- The bottom bar and focus --------------------------------------------------------------- */
   body[data-layout='nerd'] .print-footer {
-    background: transparent;
     border: 0;
-  }
-
-  body[data-layout='nerd'] .print-footer::after {
-    background: var(--g-rule-soft);
+    border-top: 1px solid var(--x-rule);
+    background: var(--x-chrome);
   }
 
   /* The download button is the page's one call to action, so it is the last place the signal is
-     spent — as a border, not as a fill: this layout paints no surfaces.
+     spent — as a border, not as a fill.
 
-     The base puts `transition: all .2s ease` on this button, and the layout is chosen by a
-     script that sets `data-layout` after the document parses: measured, first paint lands about
-     80ms into that transition, so the button was painting halfway between the base's white
-     14.4px/600 pill and this one. Nothing on a document should be moving while it is read. */
+     The base puts `transition: all .2s ease` on this button, and the layout is chosen by a script
+     that sets `data-layout` after the document parses: measured, first paint landed about 80ms
+     into that transition, so the button painted halfway between the base's white pill and this
+     one. Nothing on a document should be moving while it is read. */
   body[data-layout='nerd'] .print-button {
     transition: none;
-    padding: 12px 22px;
-    border: 1px solid var(--g-signal);
-    border-radius: 0;
+    padding: 7px 14px;
+    border: 1px solid var(--x-signal);
+    border-radius: 6px;
     background: transparent;
     box-shadow: none;
-    color: var(--g-signal);
-    font-family: var(--g-mono);
-    font-size: 11px;
+    color: var(--x-signal);
+    font-family: var(--x-mono);
+    font-size: 12px;
     font-weight: 400;
-    letter-spacing: 0.16em;
-    text-transform: uppercase;
+    letter-spacing: 0;
+    text-transform: none;
   }
 
   body[data-layout='nerd'] .print-button:hover {
+    background: transparent;
     box-shadow: none;
     transform: none;
-    background: transparent;
+    text-decoration: underline;
+    text-underline-offset: 3px;
   }
 
   body[data-layout='nerd'] .print-button-secondary {
-    border-color: var(--g-rule);
-    color: var(--g-muted);
+    border-color: var(--x-rim);
+    color: var(--x-body);
   }
 
   body[data-layout='nerd'] .print-button-secondary:hover {
-    border-color: var(--g-dim);
-    color: var(--g-body);
+    border-color: var(--x-dim);
+    color: var(--x-ink);
   }
 
   body[data-layout='nerd'] .button-icon {
-    font-family: var(--g-mono);
+    font-family: var(--x-mono);
   }
 
   body[data-layout='nerd'] a:focus-visible,
   body[data-layout='nerd'] button:focus-visible {
-    outline: 2px solid var(--g-signal);
-    outline-offset: 3px;
+    outline: 2px solid var(--x-signal);
+    outline-offset: 2px;
   }
 
-  /* --- 390px ------------------------------------------------------------------------------------- */
+  /* --- 390px ---------------------------------------------------------------------------------- */
   @media (max-width: 768px) {
-    body[data-layout='nerd'] .hero-name {
-      font-size: 36px;
-      letter-spacing: -0.032em;
-    }
-
-    body[data-layout='nerd'] .hero-title {
-      margin-top: 14px;
+    body[data-layout='nerd'] .layout-switcher a {
       font-size: 11px;
-      letter-spacing: 0.16em;
-      line-height: 1.8;
     }
 
-    body[data-layout='nerd'] .hero-summary {
-      margin-top: 22px;
-      font-size: 14px;
-      line-height: 1.66;
-    }
-
-    body[data-layout='nerd'] .profile-image-wrapper img {
-      width: 72px;
-      height: 72px;
-    }
-
-    /* Stacked, the rail's dividing rule would fall across a line start. */
-    body[data-layout='nerd'] .contact-details {
-      padding-left: 0;
-      border-left: 0;
-    }
-
-    /* Three addresses cannot share a 342px line, and a wrap left the decorative middot
-       stranded at a line's end where it reads as a typo. One address per line, and the
-       separators — `aria-hidden`, carrying no meaning — go with the line that needed them.
-       Print keeps them: this is inside @media screen. */
-    body[data-layout='nerd'] .social-links {
-      flex-basis: auto;
-      flex-direction: column;
-      align-items: flex-start;
-      gap: 2px;
-      margin-top: 6px;
-    }
-
-    body[data-layout='nerd'] .social-links .inline-separator {
-      display: none;
-    }
-
-    body[data-layout='nerd'] .job-title {
-      font-size: 17px;
-    }
-
-    body[data-layout='nerd'] .job-period {
-      margin-bottom: 10px;
-      font-size: 10.5px;
-      letter-spacing: 0.1em;
-    }
-
-    /* The tick keeps its place above the dateline; it just has less room over it. */
-    body[data-layout='nerd'] .experience-content > .job-entry:first-child .job-period::before {
-      margin-bottom: 12px;
-    }
-
-    body[data-layout='nerd'] .job-highlights li,
-    body[data-layout='nerd'] .job-description {
-      font-size: 14px;
-      line-height: 1.66;
-    }
-
-    /* One column: the vertical dividers go and the horizontal ones become the band's rows. */
-    body[data-layout='nerd'] .certifications-section,
-    body[data-layout='nerd'] .education-section,
-    body[data-layout='nerd'] .languages-section {
+    body[data-layout='nerd'] .source-editor {
       border-right: 0;
-      border-bottom: 0;
     }
 
-    body[data-layout='nerd'] .education-section,
-    body[data-layout='nerd'] .languages-section,
-    body[data-layout='nerd'] .interests-section {
-      border-top: 1px solid var(--g-rule-soft);
+    body[data-layout='nerd'] .source-preview {
+      border-bottom: 1px solid var(--x-rule);
+    }
+
+    body[data-layout='nerd'] .source-code {
+      font-size: 12px;
+    }
+
+    body[data-layout='nerd'] .source-number {
+      font-size: 10.5px;
     }
 
     body[data-layout='nerd'] .print-button {
-      justify-content: center;
-      padding: 13px;
-      font-size: 10.5px;
+      padding: 11px;
     }
   }
 }

--- a/design-glacier.css
+++ b/design-glacier.css
@@ -1361,6 +1361,7 @@ body[data-layout='technical'] .hero-name {
     --x-app-rule: #2c2f36;
     --x-app-ink: #f3f4f6;
     --x-app-muted: #9fa5ac;
+    --x-app-alert: rgb(37 40 46 / 0.88);
     --x-portrait-light: #f3f4f6;
     --x-portrait-shade: #c3c9d1;
     --x-tint: var(--x-property);
@@ -1756,6 +1757,52 @@ body[data-layout='technical'] .hero-name {
     color: var(--x-tint);
   }
 
+  /* --- The call alert ------------------------------------------------------------------------- */
+  /* The shape an app's alert has: a frosted panel, a bold title, a line of message and one tinted
+     button under a hairline. The panel is #25282E at 88%, so every word on it stays above 11:1. */
+  body[data-layout='nerd'] .app-alert {
+    border: 0;
+    border-radius: 14px;
+    background: var(--x-app-alert);
+    color: var(--x-app-ink);
+    font-family: var(--x-sans);
+    box-shadow: 0 24px 60px -12px rgb(0 0 0 / 0.6);
+    -webkit-backdrop-filter: blur(24px) saturate(1.4);
+    backdrop-filter: blur(24px) saturate(1.4);
+  }
+
+  body[data-layout='nerd'] .app-alert::backdrop {
+    background: rgb(0 0 0 / 0.45);
+  }
+
+  body[data-layout='nerd'] .app-alert-title {
+    font-size: 17px;
+    font-weight: 600;
+    line-height: 1.3;
+    letter-spacing: -0.01em;
+  }
+
+  body[data-layout='nerd'] .app-alert-message {
+    font-size: 13px;
+    line-height: 1.4;
+  }
+
+  body[data-layout='nerd'] .app-alert-actions {
+    border-top: 1px solid var(--x-app-rule);
+  }
+
+  body[data-layout='nerd'] .app-alert-button {
+    border: 0;
+    background: transparent;
+    color: var(--x-tint);
+    font: 600 17px / 1.3 var(--x-sans);
+    cursor: pointer;
+  }
+
+  body[data-layout='nerd'] .app-alert-button:hover {
+    background: rgb(255 255 255 / 0.06);
+  }
+
   body[data-layout='nerd'] .simulator-screen::after {
     background: var(--x-device);
   }
@@ -1831,25 +1878,6 @@ body[data-layout='technical'] .hero-name {
   @media (max-width: 768px) {
     body[data-layout='nerd'] .layout-switcher a {
       font-size: 11px;
-    }
-
-    /* A phone drawn on a phone keeps the phone's proportions: a floor set for a laptop would
-       overflow a screen 150px wide. */
-    body[data-layout='nerd'] .app-name {
-      font-size: 8.2cqw;
-    }
-
-    body[data-layout='nerd'] .app-title {
-      font-size: 3.9cqw;
-    }
-
-    body[data-layout='nerd'] .app-action,
-    body[data-layout='nerd'] .app-row-label {
-      font-size: 3cqw;
-    }
-
-    body[data-layout='nerd'] .app-row-value {
-      font-size: 4cqw;
     }
 
     body[data-layout='nerd'] .source-code {

--- a/design-glacier.css
+++ b/design-glacier.css
@@ -1559,7 +1559,7 @@ body[data-layout='technical'] .hero-name {
 
   body[data-layout='nerd'] .tok-keyword {
     color: var(--x-keyword);
-    font-weight: 600;
+    font-weight: 700;
   }
 
   body[data-layout='nerd'] .tok-type {
@@ -1584,7 +1584,7 @@ body[data-layout='technical'] .hero-name {
 
   body[data-layout='nerd'] .tok-macro {
     color: var(--x-signal);
-    font-weight: 600;
+    font-weight: 700;
   }
 
   /* A MARK is a section heading: the prefix in the comment's colour, the label in ink, both bold. */
@@ -1605,10 +1605,11 @@ body[data-layout='technical'] .hero-name {
     font-weight: 700;
   }
 
-  /* A link sits in a string, so colour cannot be what marks it: it is underlined. */
+  /* A link sits in a string, so colour cannot be what marks it: it is underlined, in the dim grey
+     at 5.0:1. In the rim's 1.7:1 the one mark of a link could not be seen. */
   body[data-layout='nerd'] .source-code a {
     text-decoration: underline;
-    text-decoration-color: var(--x-rim);
+    text-decoration-color: var(--x-dim);
     text-underline-offset: 3px;
   }
 
@@ -1634,7 +1635,7 @@ body[data-layout='technical'] .hero-name {
   }
 
   body[data-layout='nerd'] .source-preview-bar span:last-child {
-    color: var(--x-dim);
+    color: var(--x-muted);
   }
 
   body[data-layout='nerd'] .simulator {
@@ -1684,8 +1685,10 @@ body[data-layout='technical'] .hero-name {
     line-height: 1.3;
   }
 
+  /* The card scales with the phone, but its type does not: 18px the name, 13px the role and the
+     details, 11px the labels. Scaled with a short window the role came down to 9px on a laptop. */
   body[data-layout='nerd'] .app-name {
-    font-size: 8.2cqw;
+    font-size: max(8.2cqw, 18px);
     font-weight: 600;
     line-height: 1.15;
     letter-spacing: -0.02em;
@@ -1693,15 +1696,20 @@ body[data-layout='technical'] .hero-name {
 
   body[data-layout='nerd'] .app-title {
     color: var(--x-app-muted);
-    font-size: 3.9cqw;
+    font-size: max(3.9cqw, 13px);
     line-height: 1.35;
   }
 
   body[data-layout='nerd'] .app-action {
     background: var(--x-app-cell);
     color: var(--x-tint);
-    font-size: 3cqw;
+    font-size: max(3cqw, 11px);
     font-weight: 500;
+    text-decoration: none;
+  }
+
+  body[data-layout='nerd'] .app-action:hover {
+    background: var(--x-raised);
   }
 
   /* The glyphs are masks filled with the text colour, so the tint lives in one token. */
@@ -1733,12 +1741,13 @@ body[data-layout='technical'] .hero-name {
 
   body[data-layout='nerd'] .app-row-label {
     color: var(--x-app-muted);
-    font-size: 3cqw;
+    font-size: max(3cqw, 11px);
   }
 
   body[data-layout='nerd'] .app-row-value {
     color: var(--x-app-ink);
-    font-size: 4cqw;
+    font-size: max(4cqw, 13px);
+    text-decoration: none;
   }
 
   /* A number and an address are what an app tints: they are where a tap would go. */
@@ -1809,17 +1818,38 @@ body[data-layout='technical'] .hero-name {
   }
 
   /* --- 390px ---------------------------------------------------------------------------------- */
-  @media (max-width: 768px) {
-    body[data-layout='nerd'] .layout-switcher a {
-      font-size: 11px;
-    }
-
+  @media (max-width: 1000px) {
     body[data-layout='nerd'] .source-editor {
       border-right: 0;
     }
 
     body[data-layout='nerd'] .source-preview {
       border-bottom: 1px solid var(--x-rule);
+    }
+  }
+
+  @media (max-width: 768px) {
+    body[data-layout='nerd'] .layout-switcher a {
+      font-size: 11px;
+    }
+
+    /* A phone drawn on a phone keeps the phone's proportions: a floor set for a laptop would
+       overflow a screen 150px wide. */
+    body[data-layout='nerd'] .app-name {
+      font-size: 8.2cqw;
+    }
+
+    body[data-layout='nerd'] .app-title {
+      font-size: 3.9cqw;
+    }
+
+    body[data-layout='nerd'] .app-action,
+    body[data-layout='nerd'] .app-row-label {
+      font-size: 3cqw;
+    }
+
+    body[data-layout='nerd'] .app-row-value {
+      font-size: 4cqw;
     }
 
     body[data-layout='nerd'] .source-code {

--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="style.css?v=20260909-print4" />
-    <link rel="stylesheet" href="layouts.css?v=20260909-print4" />
-    <link rel="stylesheet" href="design-glacier.css?v=20260909-print4" />
-    <link rel="stylesheet" href="print.css?v=20260909-print4" media="print" />
-    <script type="module" defer src="script.js?v=20260909-print4"></script>
+    <link rel="stylesheet" href="style.css?v=20260910-xcode1" />
+    <link rel="stylesheet" href="layouts.css?v=20260910-xcode1" />
+    <link rel="stylesheet" href="design-glacier.css?v=20260910-xcode1" />
+    <link rel="stylesheet" href="print.css?v=20260910-xcode1" media="print" />
+    <script type="module" defer src="script.js?v=20260910-xcode1"></script>
   </head>
   <body>
     <nav
@@ -26,6 +26,42 @@
       <a data-layout-link="spotlight" data-i18n="layouts.spotlight">Impact Spotlight</a>
       <a data-layout-link="technical" data-i18n="layouts.technical">Technical Profile</a>
     </nav>
+    <!-- Nerd Mode's editor: the same profile as a Swift file. It stays hidden unless the nerd
+         layout's screen stylesheet shows it, so paper, every other layout and a page without CSS
+         never meet it. renderers/SourceRenderer.js writes the file. -->
+    <div class="source-view" hidden>
+      <nav
+        class="source-navigator"
+        aria-label="Sections"
+        data-i18n-attr="aria-label:source.outline"
+      >
+        <p class="source-navigator-file" aria-hidden="true"><span data-source-file></span></p>
+        <ol id="source-outline" class="source-outline"></ol>
+      </nav>
+      <div class="source-editor">
+        <p class="source-tabs" aria-hidden="true">
+          <span class="source-tab" data-source-file></span>
+        </p>
+        <div id="source-code" class="source-code"></div>
+      </div>
+      <aside class="source-preview" aria-label="Preview" data-i18n-attr="aria-label:source.preview">
+        <p class="source-preview-bar" aria-hidden="true">
+          <span data-i18n="source.preview">Preview</span>
+          <span data-i18n="source.device">iPhone</span>
+        </p>
+        <div class="simulator">
+          <div class="simulator-screen">
+            <img
+              class="simulator-portrait"
+              src="profile.webp"
+              alt=""
+              data-i18n-attr="alt:accessibility.profilePhoto"
+            />
+            <div id="source-card" class="app-card" aria-hidden="true"></div>
+          </div>
+        </div>
+      </aside>
+    </div>
     <div class="container">
       <!-- Hero Section with Key Info -->
       <header class="hero-section">

--- a/index.html
+++ b/index.html
@@ -7,14 +7,14 @@
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link
-      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&family=JetBrains+Mono:wght@400;600;700&display=swap"
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="style.css?v=20260910-xcode1" />
-    <link rel="stylesheet" href="layouts.css?v=20260910-xcode1" />
-    <link rel="stylesheet" href="design-glacier.css?v=20260910-xcode1" />
-    <link rel="stylesheet" href="print.css?v=20260910-xcode1" media="print" />
-    <script type="module" defer src="script.js?v=20260910-xcode1"></script>
+    <link rel="stylesheet" href="style.css?v=20260910-xcode2" />
+    <link rel="stylesheet" href="layouts.css?v=20260910-xcode2" />
+    <link rel="stylesheet" href="design-glacier.css?v=20260910-xcode2" />
+    <link rel="stylesheet" href="print.css?v=20260910-xcode2" media="print" />
+    <script type="module" defer src="script.js?v=20260910-xcode2"></script>
   </head>
   <body>
     <nav
@@ -46,8 +46,8 @@
       </div>
       <aside class="source-preview" aria-label="Preview" data-i18n-attr="aria-label:source.preview">
         <p class="source-preview-bar" aria-hidden="true">
-          <span data-i18n="source.preview">Preview</span>
-          <span data-i18n="source.device">iPhone</span>
+          <span data-i18n-attr="data-text:source.preview"></span>
+          <span data-i18n-attr="data-text:source.device"></span>
         </p>
         <div class="simulator">
           <div class="simulator-screen">
@@ -57,7 +57,7 @@
               alt=""
               data-i18n-attr="alt:accessibility.profilePhoto"
             />
-            <div id="source-card" class="app-card" aria-hidden="true"></div>
+            <div id="source-card" class="app-card"></div>
           </div>
         </div>
       </aside>

--- a/index.html
+++ b/index.html
@@ -10,11 +10,11 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700&display=swap"
       rel="stylesheet"
     />
-    <link rel="stylesheet" href="style.css?v=20260910-xcode2" />
-    <link rel="stylesheet" href="layouts.css?v=20260910-xcode2" />
-    <link rel="stylesheet" href="design-glacier.css?v=20260910-xcode2" />
-    <link rel="stylesheet" href="print.css?v=20260910-xcode2" media="print" />
-    <script type="module" defer src="script.js?v=20260910-xcode2"></script>
+    <link rel="stylesheet" href="style.css?v=20260911-xcode3" />
+    <link rel="stylesheet" href="layouts.css?v=20260911-xcode3" />
+    <link rel="stylesheet" href="design-glacier.css?v=20260911-xcode3" />
+    <link rel="stylesheet" href="print.css?v=20260911-xcode3" media="print" />
+    <script type="module" defer src="script.js?v=20260911-xcode3"></script>
   </head>
   <body>
     <nav
@@ -61,6 +61,20 @@
           </div>
         </div>
       </aside>
+      <!-- The call button's easter egg: an alert telling the reader to dial the number themselves. -->
+      <dialog
+        id="source-call"
+        class="app-alert"
+        role="alertdialog"
+        aria-labelledby="source-call-title"
+        aria-describedby="source-call-message"
+      >
+        <h2 id="source-call-title" class="app-alert-title"></h2>
+        <p id="source-call-message" class="app-alert-message"></p>
+        <form method="dialog" class="app-alert-actions">
+          <button id="source-call-dismiss" class="app-alert-button" type="submit"></button>
+        </form>
+      </dialog>
     </div>
     <div class="container">
       <!-- Hero Section with Key Info -->

--- a/layouts.css
+++ b/layouts.css
@@ -30,432 +30,497 @@
 }
 
 /* Nerd Mode — the arrangement.
-   A single sheet of anthracite with nothing on it but rules. There is no card, no panel and no
-   second surface, so the page has no edge of its own: what organises it is a fixed 178px
-   monospace column down the left — dates beside a role, a category beside its skills — and a
-   hairline wherever two things must be told apart. This block is the arrangement only; the
-   colour, the type and the hairlines themselves live in design-glacier.css under "Nerd Mode —
-   the skin", which loads after this file and has to, because it overrides the shared masthead
-   and section rules that file defines above.
+   The CV as a Swift file open in an editor: a toolbar across the top, the file's sections down a
+   navigator on the left, the source in the middle, and a phone on the right running the file's
+   #Preview — a contact card around the portrait. The page scrolls as a document; the toolbar, the
+   tab, the navigator and the phone hold still beside it.
 
-   Screen-only, like spotlight and technical: on paper print.css lays the base DOM out on its own
-   two-column grid, and a `display: contents` or a grid placement leaking into it would break
-   that. The paper layout gets its own, deliberately smaller treatment at the foot of print.css. */
+   The source is not the base DOM restyled. It is a second rendering of the same profile, written
+   into `.source-view` by renderers/SourceRenderer.js from the lines adapters/SwiftSourceLayout.js
+   composes, because a Swift file is a different shape to the page's sections — lines, depth,
+   brackets that close — and no stylesheet turns a card into a closing parenthesis. On screen the
+   base sections step aside. They remain what paper prints: `.source-view` carries `hidden`, and
+   only this block overrides it, so in print, in the other two layouts and without a stylesheet the
+   file does not exist.
+
+   What the editor draws is decoration and what it says is the CV. Every keyword, quote, bracket
+   and line number comes from `data-code` or a counter, on elements marked `aria-hidden`, so a
+   selection, a screen reader and a search meet the profile's words and nothing else.
+
+   This block is the arrangement only; the colour, the type and the syntax live in
+   design-glacier.css under "Nerd Mode — the skin". */
 @media screen {
-  /* The measure and the gutter, in one place: the section paddings, the masthead and the footer
-     all hang off them, and the credentials band divides the measure into four. */
+  /* The editor's geometry, in one place. `--x-indent` is in `ch` and resolves on each line, in the
+     code face, so an indent is four characters whatever the fallback font measures. The phone is
+     as tall as the window allows, between a height it still reads at and the 620px it is drawn
+     for. */
   body[data-layout='nerd'] {
-    --g-measure: 1100px;
-    --g-gutter: 76px;
-    --g-rail: 178px;
-    --g-rail-gap: 24px;
-  }
+    --x-toolbar: 52px;
+    --x-tabs: 36px;
+    --x-navigator: 248px;
+    --x-preview: 392px;
+    --x-line: 24px;
+    --x-gutter: 64px;
+    --x-number-gap: 20px;
+    --x-indent: 4ch;
+    --x-code-right: 28px;
+    --x-phone: clamp(360px, calc(100vh - var(--x-toolbar) - var(--x-tabs) - 88px), 620px);
 
-  /* The body's own padding goes so the ground reaches the window on every side. Nothing is
-     lifted off it: the container is the same anthracite, with no radius, shadow or border. */
-  body[data-layout='nerd'] {
+    display: flex;
+    flex-direction: column;
+    min-height: 100vh;
     padding: 0;
   }
 
+  /* The base sections step aside; the footer stays, as the editor's bottom bar. */
+  body[data-layout='nerd'] .hero-section,
+  body[data-layout='nerd'] .skills-spotlight,
+  body[data-layout='nerd'] .main-content {
+    display: none;
+  }
+
   body[data-layout='nerd'] .container {
-    max-width: var(--g-measure);
+    width: 100%;
+    max-width: none;
+    margin: 0;
     border-radius: 0;
     box-shadow: none;
     overflow: visible;
-    counter-reset: nerd-section;
   }
 
-  /* The switcher stops being a floating pill and becomes the sheet's top strip, aligned to the
-     same gutter as everything below it. */
+  /* --- The toolbar --------------------------------------------------------------------------- */
+  /* The layout switcher, pinned, with the window's three dots drawn in the room its padding
+     leaves. The links become one segmented control: they share their borders and only the ends
+     round. */
   body[data-layout='nerd'] .layout-switcher {
-    max-width: var(--g-measure);
+    position: sticky;
+    top: 0;
+    z-index: 3;
     justify-content: flex-start;
+    align-items: center;
     gap: 0;
-    margin: 0 auto;
-    padding: 20px var(--g-gutter);
+    max-width: none;
+    height: var(--x-toolbar);
+    margin: 0;
+    padding: 0 18px 0 94px;
+  }
+
+  body[data-layout='nerd'] .layout-switcher::before {
+    content: '';
+    position: absolute;
+    top: 50%;
+    left: 18px;
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    transform: translateY(-50%);
   }
 
   body[data-layout='nerd'] .layout-switcher a {
     flex: none;
-    padding: 6px 18px 6px 0;
-    text-align: left;
+    padding: 6px 12px;
+    text-align: center;
   }
 
-  /* --- The masthead ------------------------------------------------------------------------ */
-  /* Identity left, portrait right, the contact rail across the foot of both. The sidebar steps
-     out of the box tree so the portrait and the rail can take their own places, the same
-     technique spotlight uses. */
-  body[data-layout='nerd'] .hero-section {
-    padding: 66px var(--g-gutter) 0;
+  body[data-layout='nerd'] .layout-switcher a + a {
+    margin-left: -1px;
   }
 
-  body[data-layout='nerd'] .hero-content {
-    grid-template-columns: minmax(0, 1fr) 104px;
-    grid-template-areas:
-      'text portrait'
-      'contact contact';
-    column-gap: 40px;
-    row-gap: 34px;
+  /* --- The three panes ------------------------------------------------------------------------ */
+  body[data-layout='nerd'] .source-view {
+    display: grid;
+    grid-template-columns: var(--x-navigator) minmax(0, 1fr) var(--x-preview);
     align-items: start;
+    flex: 1 0 auto;
   }
 
-  body[data-layout='nerd'] .hero-sidebar {
-    display: contents;
+  /* The navigator and the phone hold still while the file scrolls past them: each is a grid item
+     as tall as the window, sticking inside a grid area as tall as the file. */
+  body[data-layout='nerd'] .source-navigator,
+  body[data-layout='nerd'] .source-preview {
+    position: sticky;
+    top: var(--x-toolbar);
+    height: calc(100vh - var(--x-toolbar));
+    overflow-y: auto;
   }
 
-  body[data-layout='nerd'] .hero-text {
-    grid-area: text;
+  body[data-layout='nerd'] .source-navigator {
+    padding: 12px 10px;
   }
 
-  body[data-layout='nerd'] .profile-image-wrapper {
-    grid-area: portrait;
-  }
-
-  body[data-layout='nerd'] .contact-card {
-    grid-area: contact;
-    display: flex;
-    flex-wrap: wrap;
-    align-items: baseline;
-    gap: 10px 22px;
-  }
-
-  body[data-layout='nerd'] .contact-item,
-  body[data-layout='nerd'] .contact-details {
-    margin: 0;
-  }
-
-  /* The template breaks the two addresses onto two lines with a <br>; the rail wants one line.
-     Print keeps the break: this rule is screen-only, like everything in this block. */
-  body[data-layout='nerd'] .contact-details br {
-    display: none;
-  }
-
-  body[data-layout='nerd'] .contact-details strong:nth-of-type(2) {
-    margin-left: 18px;
-  }
-
-  body[data-layout='nerd'] .social-links {
-    gap: 0;
-  }
-
-  /* --- The section heads -------------------------------------------------------------------- */
-  /* A number, a word, and a rule that runs to the margin. The number is a counter, so it comes
-     from the stylesheet and never from the DOM: nothing a parser reads back changes. A section
-     the renderers hide carries `display: none` and does not increment, so an empty section
-     leaves no gap in the numbering. */
-  body[data-layout='nerd'] .spotlight-title,
-  body[data-layout='nerd'] .section-title {
+  body[data-layout='nerd'] .source-navigator-file,
+  body[data-layout='nerd'] .source-outline a {
     display: flex;
     align-items: center;
-    gap: 16px;
-    margin: 0 0 26px;
+    gap: 8px;
+    min-height: 26px;
+    margin: 0;
+    padding: 0 8px;
+  }
+
+  body[data-layout='nerd'] .source-outline {
+    margin: 2px 0 0;
     padding: 0;
-    counter-increment: nerd-section;
+    list-style: none;
   }
 
-  body[data-layout='nerd'] .spotlight-title::before,
-  body[data-layout='nerd'] .section-title::before {
-    content: counter(nerd-section, decimal-leading-zero);
-    flex: none;
+  body[data-layout='nerd'] .source-outline a {
+    padding-left: 42px;
   }
 
-  body[data-layout='nerd'] .spotlight-title::after,
-  body[data-layout='nerd'] .section-title::after {
-    content: '';
-    flex: 1;
-    height: 1px;
+  /* A jump from the navigator lands below the pinned toolbar and tab, not under them. */
+  body[data-layout='nerd'] .source-line[id] {
+    scroll-margin-top: calc(var(--x-toolbar) + var(--x-tabs) + 12px);
   }
 
-  /* --- 01 The skills table ------------------------------------------------------------------ */
-  /* A ruled table: the category holds the rail, the names run as text beside it. Pills belong to
-     technical; nothing here is boxed. */
-  body[data-layout='nerd'] .skills-spotlight {
-    padding: 60px var(--g-gutter) 0;
+  body[data-layout='nerd'] .source-editor {
+    min-width: 0;
   }
 
-  body[data-layout='nerd'] .skills-showcase {
-    display: block;
-    max-width: none;
+  body[data-layout='nerd'] .source-tabs {
+    position: sticky;
+    top: var(--x-toolbar);
+    z-index: 2;
+    display: flex;
+    height: var(--x-tabs);
     margin: 0;
   }
 
-  body[data-layout='nerd'] .skill-group {
-    display: grid;
-    grid-template-columns: var(--g-rail) minmax(0, 1fr);
-    gap: 0 var(--g-rail-gap);
-    align-items: start;
-    padding: 15px 0;
+  body[data-layout='nerd'] .source-tab {
+    margin-bottom: -1px;
+    padding: 0 16px;
   }
 
-  body[data-layout='nerd'] .skill-category,
-  body[data-layout='nerd'] .skill-list {
-    display: block;
-    flex: none;
-  }
-
-  /* --- 02 The experience -------------------------------------------------------------------- */
-  body[data-layout='nerd'] .main-content {
-    padding: 60px var(--g-gutter) 0;
-  }
-
-  /* Both columns step out of the box tree so their five sections can take places in one grid:
-     the experience spans the full measure, and the four short sections that follow it become the
-     credentials band beneath. The DOM order is untouched — a parser still reads experience,
-     certifications, education, languages, interests. */
-  /* The band's four columns stretch to the tallest of them, so the rule that closes the band
-     runs straight across and the dividers between the columns reach it. Left to `start` each
-     column ended at its own last line and the band came out as a staircase. */
-  body[data-layout='nerd'] .content-grid {
-    display: grid;
-    grid-template-columns: repeat(4, minmax(0, 1fr));
-    gap: 62px 0;
-    align-items: stretch;
-  }
-
-  body[data-layout='nerd'] .primary-column,
-  body[data-layout='nerd'] .secondary-column {
-    display: contents;
-  }
-
-  body[data-layout='nerd'] .experience-section {
-    grid-column: 1 / -1;
-    grid-row: 1;
-  }
-
-  body[data-layout='nerd'] .certifications-section {
-    grid-column: 1;
-    grid-row: 2;
-    padding: 26px 26px 30px 0;
-  }
-
-  body[data-layout='nerd'] .education-section {
-    grid-column: 2;
-    grid-row: 2;
-    padding: 26px;
-  }
-
-  body[data-layout='nerd'] .languages-section {
-    grid-column: 3;
-    grid-row: 2;
-    padding: 26px;
-  }
-
-  body[data-layout='nerd'] .interests-section {
-    grid-column: 4;
-    grid-row: 2;
-    padding: 26px 0 30px 26px;
-  }
-
-  /* The grid's gaps are the rhythm; the base margins would double them. */
-  body[data-layout='nerd'] section,
-  body[data-layout='nerd'] .primary-column > section + section,
-  body[data-layout='nerd'] .secondary-column > section + section {
-    margin: 0;
-  }
-
-  /* A role: its dates hold the rail, everything else runs in the column beside them. The DOM
-     keeps the title first, so a screen reader and a parser meet the role before the period. */
-  body[data-layout='nerd'] .job-entry {
-    display: grid;
-    grid-template-columns: var(--g-rail) minmax(0, 1fr);
-    column-gap: var(--g-rail-gap);
-    row-gap: 0;
-    align-items: start;
-    padding: 0 0 38px;
-    border: 0;
-    border-radius: 0;
-    box-shadow: none;
-  }
-
-  body[data-layout='nerd'] .job-entry > * {
-    grid-column: 2;
-  }
-
-  body[data-layout='nerd'] .job-period {
-    grid-column: 1;
-    grid-row: 1;
-  }
-
-  body[data-layout='nerd'] .job-header {
-    grid-row: 1;
-  }
-
-  body[data-layout='nerd'] .job-entry + .job-entry {
-    margin: 0;
-    padding-top: 34px;
-  }
-
-  body[data-layout='nerd'] .experience-content > .job-entry:last-child {
-    padding-bottom: 0;
-  }
-
-  body[data-layout='nerd'] .job-highlights {
-    margin: 18px 0 0;
-    padding: 0;
-  }
-
-  /* --- 03-06 The credentials band ------------------------------------------------------------ */
-  body[data-layout='nerd'] .edu-entry {
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-    box-shadow: none;
-  }
-
-  body[data-layout='nerd'] .edu-entry + .edu-entry {
-    margin-top: 16px;
-  }
-
-  body[data-layout='nerd'] .certifications-list li {
-    padding: 0;
-    border: 0;
-    border-radius: 0;
-  }
-
-  body[data-layout='nerd'] .certifications-list li + li {
-    margin-top: 16px;
-  }
-
-  body[data-layout='nerd'] .languages-list li {
-    padding: 0;
-    border: 0;
-  }
-
-  body[data-layout='nerd'] .languages-list li + li {
-    margin-top: 12px;
-  }
-
-  body[data-layout='nerd'] .interests-tags {
-    display: block;
-  }
-
-  /* --- The footer ---------------------------------------------------------------------------- */
-  body[data-layout='nerd'] .print-footer {
-    justify-content: flex-start;
+  body[data-layout='nerd'] [data-source-file] {
+    display: inline-flex;
     align-items: center;
-    gap: 14px;
-    padding: 40px var(--g-gutter) 74px;
-  }
-
-  /* The rule that closes the sheet, drawn in the space the two buttons leave. */
-  body[data-layout='nerd'] .print-footer::after {
-    content: '';
-    flex: 1;
-    height: 1px;
-  }
-}
-
-/* Nerd Mode at 390px: the rail has nowhere to go, so it unstacks. Dates rise above their role,
-   categories above their skills, and the four-column band becomes four ruled rows. */
-@media screen and (max-width: 768px) {
-  body[data-layout='nerd'] {
-    --g-gutter: 24px;
-  }
-
-  body[data-layout='nerd'] .layout-switcher {
-    flex-wrap: wrap;
-    gap: 0 4px;
-    padding: 14px var(--g-gutter);
-  }
-
-  body[data-layout='nerd'] .hero-section {
-    padding: 40px var(--g-gutter) 0;
-  }
-
-  body[data-layout='nerd'] .hero-content {
-    grid-template-columns: minmax(0, 1fr);
-    grid-template-areas:
-      'portrait'
-      'text'
-      'contact';
-    row-gap: 22px;
-    text-align: left;
-  }
-
-  body[data-layout='nerd'] .contact-card {
-    flex-direction: column;
-    align-items: flex-start;
     gap: 8px;
   }
 
-  /* Narrow screens get the template's line break back: "Phone:" stranded at a line's end with
-     its number on the next reads as a mistake. */
-  body[data-layout='nerd'] .contact-details br {
+  /* --- The source ----------------------------------------------------------------------------- */
+  /* One element per line. The first row of a line starts at its depth; the rows it wraps onto hang
+     one indent further in, the way an editor with line wrapping sets a long string, so a wrapped
+     achievement never reads as a new line of code. The number sits in the gutter and is counted,
+     never written. */
+  body[data-layout='nerd'] .source-code {
+    counter-reset: source-line;
+    padding: 14px 0 56px;
+  }
+
+  body[data-layout='nerd'] .source-line {
+    position: relative;
+    min-height: var(--x-line);
+    margin: 0;
+    padding: 0 var(--x-code-right) 0 calc(var(--x-gutter) + (var(--depth, 0) + 1) * var(--x-indent));
+    text-indent: calc(-1 * var(--x-indent));
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    counter-increment: source-line;
+  }
+
+  body[data-layout='nerd'] .source-line[data-depth='1'] {
+    --depth: 1;
+  }
+
+  body[data-layout='nerd'] .source-line[data-depth='2'] {
+    --depth: 2;
+  }
+
+  body[data-layout='nerd'] .source-line[data-depth='3'] {
+    --depth: 3;
+  }
+
+  body[data-layout='nerd'] .source-line[data-depth='4'] {
+    --depth: 4;
+  }
+
+  body[data-layout='nerd'] .source-line[data-depth='5'] {
+    --depth: 5;
+  }
+
+  body[data-layout='nerd'] .source-number {
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: calc(var(--x-gutter) - var(--x-number-gap));
+    text-align: right;
+    text-indent: 0;
+    user-select: none;
+  }
+
+  body[data-layout='nerd'] .source-number::before {
+    content: counter(source-line);
+  }
+
+  body[data-layout='nerd'] .tok[data-code]::before {
+    content: attr(data-code);
+  }
+
+  /* The name and the roles are headings to a screen reader and part of a line to the eye. */
+  body[data-layout='nerd'] .source-line h1,
+  body[data-layout='nerd'] .source-line h3 {
     display: inline;
+    margin: 0;
   }
 
-  body[data-layout='nerd'] .contact-details strong:nth-of-type(2) {
-    margin-left: 0;
+  /* --- The preview ---------------------------------------------------------------------------- */
+  body[data-layout='nerd'] .source-preview {
+    display: flex;
+    flex-direction: column;
   }
 
-  body[data-layout='nerd'] .skills-spotlight,
-  body[data-layout='nerd'] .main-content {
-    padding: 44px var(--g-gutter) 0;
+  body[data-layout='nerd'] .source-preview-bar {
+    display: flex;
+    flex: none;
+    align-items: center;
+    justify-content: space-between;
+    height: var(--x-tabs);
+    margin: 0;
+    padding: 0 16px;
   }
 
-  body[data-layout='nerd'] .skill-group {
+  /* A phone at a phone's proportions. Its padding and radii follow its height, so a shorter window
+     gets a smaller phone rather than a squarer one. */
+  body[data-layout='nerd'] .simulator {
+    position: relative;
+    flex: none;
+    height: var(--x-phone);
+    aspect-ratio: 150 / 310;
+    margin: auto;
+    padding: calc(var(--x-phone) * 0.0177);
+    border-radius: 16.7% / 8.1%;
+  }
+
+  /* The hardware keys: a strip down each side, cut into keys by the skin's gradient. */
+  body[data-layout='nerd'] .simulator::before,
+  body[data-layout='nerd'] .simulator::after {
+    content: '';
+    position: absolute;
+    width: 3px;
+  }
+
+  body[data-layout='nerd'] .simulator::before {
+    top: 20%;
+    left: -4px;
+    height: 29%;
+    border-radius: 2px 0 0 2px;
+  }
+
+  body[data-layout='nerd'] .simulator::after {
+    top: 31%;
+    right: -4px;
+    height: 14%;
+    border-radius: 0 2px 2px 0;
+  }
+
+  /* The screen is a size container: everything on it is measured in `cqw`, hundredths of the
+     screen's width, so the app scales with the phone as one picture and never reflows. */
+  body[data-layout='nerd'] .simulator-screen {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    height: 100%;
+    overflow: hidden;
+    border-radius: 14% / 6.5%;
+    container-type: inline-size;
+  }
+
+  /* The camera cut-out, over the top of the app. */
+  body[data-layout='nerd'] .simulator-screen::after {
+    content: '';
+    position: absolute;
+    top: 2%;
+    left: 50%;
+    width: 31%;
+    height: 4.2%;
+    border-radius: 999px;
+    transform: translateX(-50%);
+  }
+
+  /* --- The app on the screen ------------------------------------------------------------------ */
+  /* A contact card: the portrait in a circle, the name and the role under it, a row of actions and
+     the details in one grouped list. */
+  body[data-layout='nerd'] .simulator-portrait {
+    flex: none;
+    width: 42cqw;
+    height: 42cqw;
+    margin-top: 21cqw;
+    border-radius: 50%;
+    object-fit: cover;
+    object-position: 50% 30%;
+  }
+
+  body[data-layout='nerd'] .app-card {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+    padding: 0 5cqw;
+  }
+
+  body[data-layout='nerd'] .app-name,
+  body[data-layout='nerd'] .app-title {
+    margin: 0;
+    text-align: center;
+    overflow-wrap: anywhere;
+  }
+
+  body[data-layout='nerd'] .app-name {
+    margin-top: 4.6cqw;
+  }
+
+  body[data-layout='nerd'] .app-title {
+    margin-top: 1.4cqw;
+    padding: 0 4cqw;
+  }
+
+  /* As many equal columns as there are actions; the layout gives it four at most. */
+  body[data-layout='nerd'] .app-actions {
+    display: grid;
+    grid-auto-columns: minmax(0, 1fr);
+    grid-auto-flow: column;
+    gap: 2.2cqw;
+    margin: 6cqw 0 0;
+    padding: 0;
+    list-style: none;
+  }
+
+  body[data-layout='nerd'] .app-action {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    gap: 1.2cqw;
+    height: 15cqw;
+    border-radius: 3.4cqw;
+  }
+
+  body[data-layout='nerd'] .app-action::before {
+    content: '';
+    width: 5.6cqw;
+    height: 5.6cqw;
+  }
+
+  body[data-layout='nerd'] .app-rows {
+    margin: 5cqw 0 0;
+    padding: 0;
+    overflow: hidden;
+    border-radius: 3.6cqw;
+    list-style: none;
+  }
+
+  body[data-layout='nerd'] .app-row {
+    display: flex;
+    flex-direction: column;
+    gap: 0.6cqw;
+    padding: 2.6cqw 4cqw;
+    overflow-wrap: anywhere;
+  }
+
+  /* Every word on the card is drawn from `data-text`: the file already says each of them as
+     text, and a card that wrote them again would be read twice. */
+  body[data-layout='nerd'] .app-name::before,
+  body[data-layout='nerd'] .app-title::before,
+  body[data-layout='nerd'] .app-action::after,
+  body[data-layout='nerd'] .app-row-label::before,
+  body[data-layout='nerd'] .app-row-value::before {
+    content: attr(data-text);
+  }
+
+  /* --- The bottom bar ------------------------------------------------------------------------- */
+  body[data-layout='nerd'] .print-footer {
+    justify-content: flex-start;
+    align-items: center;
+    gap: 10px;
+    margin: 0;
+    padding: 9px 18px;
+  }
+}
+
+/* Nerd Mode below a laptop: the navigator goes first — the file's own MARK lines carry the same
+   sections — and the phone takes a narrower pane. */
+@media screen and (max-width: 1180px) {
+  body[data-layout='nerd'] {
+    --x-preview: 320px;
+    --x-phone: clamp(360px, calc(100vh - var(--x-toolbar) - var(--x-tabs) - 88px), 540px);
+  }
+
+  body[data-layout='nerd'] .source-view {
+    grid-template-columns: minmax(0, 1fr) var(--x-preview);
+  }
+
+  body[data-layout='nerd'] .source-navigator {
+    display: none;
+  }
+}
+
+/* Nerd Mode at 390px: one column. The code keeps its line numbers and loses width everywhere else —
+   a two-character indent and a narrower gutter — so an achievement three levels deep still gets
+   forty characters a row. The phone follows the window's height and stops at 340px: at a fixed
+   404px it pushed the name below the first screen of a 667px phone. */
+@media screen and (max-width: 768px) {
+  body[data-layout='nerd'] {
+    --x-line: 20px;
+    --x-gutter: 40px;
+    --x-number-gap: 10px;
+    --x-indent: 2ch;
+    --x-code-right: 12px;
+    --x-phone: clamp(240px, 42vh, 340px);
+  }
+
+  /* The toolbar unpins and gives up its dots: on a phone the switcher needs the whole width. */
+  body[data-layout='nerd'] .layout-switcher {
+    position: static;
+    height: auto;
+    padding: 10px 12px;
+  }
+
+  body[data-layout='nerd'] .layout-switcher::before {
+    display: none;
+  }
+
+  body[data-layout='nerd'] .layout-switcher a {
+    flex: 1 1 0;
+    padding: 7px 4px;
+  }
+
+  /* The phone comes first, as the portrait did before. It moves by `order`, which leaves the
+     document order — and a screen reader's — with the file first. */
+  body[data-layout='nerd'] .source-view {
     grid-template-columns: minmax(0, 1fr);
-    gap: 7px;
-    padding: 14px 0;
   }
 
-  /* One column, and the band becomes four ruled rows that must sit flush against each other:
-     the grid gap goes and the experience carries the distance to the band on its own margin. */
-  body[data-layout='nerd'] .content-grid {
-    grid-template-columns: minmax(0, 1fr);
-    gap: 0;
+  body[data-layout='nerd'] .source-preview {
+    order: -1;
+    position: static;
+    height: auto;
+    overflow: visible;
+    padding: 26px 0 30px;
   }
 
-  body[data-layout='nerd'] .experience-section {
-    margin-bottom: 44px;
+  body[data-layout='nerd'] .source-preview-bar {
+    display: none;
   }
 
-  body[data-layout='nerd'] .experience-section,
-  body[data-layout='nerd'] .certifications-section,
-  body[data-layout='nerd'] .education-section,
-  body[data-layout='nerd'] .languages-section,
-  body[data-layout='nerd'] .interests-section {
-    grid-column: 1;
-    grid-row: auto;
+  body[data-layout='nerd'] .source-tabs {
+    top: 0;
   }
 
-  body[data-layout='nerd'] .certifications-section,
-  body[data-layout='nerd'] .education-section,
-  body[data-layout='nerd'] .languages-section,
-  body[data-layout='nerd'] .interests-section {
-    padding: 20px 0;
+  body[data-layout='nerd'] .source-line[id] {
+    scroll-margin-top: calc(var(--x-tabs) + 12px);
   }
 
-  body[data-layout='nerd'] .job-entry {
-    grid-template-columns: minmax(0, 1fr);
-    padding-bottom: 30px;
-  }
-
-  body[data-layout='nerd'] .job-entry > * {
-    grid-column: 1;
-  }
-
-  body[data-layout='nerd'] .job-period {
-    grid-row: 1;
-  }
-
-  body[data-layout='nerd'] .job-header {
-    grid-row: 2;
-  }
-
-  body[data-layout='nerd'] .job-entry + .job-entry {
-    padding-top: 26px;
+  body[data-layout='nerd'] .source-code {
+    padding: 12px 0 32px;
   }
 
   body[data-layout='nerd'] .print-footer {
-    flex-direction: column;
-    align-items: stretch;
-    gap: 10px;
-    padding: 36px var(--g-gutter) 48px;
+    padding: 16px 12px 22px;
   }
 
-  body[data-layout='nerd'] .print-footer::after {
-    display: none;
+  body[data-layout='nerd'] .print-button {
+    flex: 1 1 0;
+    justify-content: center;
   }
 }
 

--- a/layouts.css
+++ b/layouts.css
@@ -289,16 +289,17 @@
     content: attr(data-text);
   }
 
-  /* A phone at a phone's proportions. Its padding and radii follow its height, so a shorter window
-     gets a smaller phone rather than a squarer one. */
+  /* A phone at the proportions of an iPhone 17 Pro Max: a body of 78 × 163.4mm around a screen of
+     440 × 956pt, which the bezel below leaves exactly. Its padding and radii follow its height, so
+     a shorter window gets a smaller phone rather than a squarer one. */
   body[data-layout='nerd'] .simulator {
     position: relative;
     flex: none;
     height: var(--x-phone);
-    aspect-ratio: 150 / 310;
+    aspect-ratio: 780 / 1634;
     margin: auto;
-    padding: calc(var(--x-phone) * 0.0177);
-    border-radius: 16.7% / 8.1%;
+    padding: calc(var(--x-phone) * 0.0158);
+    border-radius: 15.5% / 7.4%;
   }
 
   /* The hardware keys: a strip down each side, cut into keys by the skin's gradient. */
@@ -332,7 +333,7 @@
     align-items: center;
     height: 100%;
     overflow: hidden;
-    border-radius: 14% / 6.5%;
+    border-radius: 13% / 6%;
     container-type: inline-size;
   }
 
@@ -340,10 +341,10 @@
   body[data-layout='nerd'] .simulator-screen::after {
     content: '';
     position: absolute;
-    top: 2%;
+    top: 1.2%;
     left: 50%;
-    width: 31%;
-    height: 4.2%;
+    width: 28.6%;
+    height: 3.9%;
     border-radius: 999px;
     transform: translateX(-50%);
   }
@@ -399,9 +400,13 @@
     display: flex;
   }
 
-  /* An action is a link: a tap on "call" calls. */
+  /* An action is a control: a link, or for "call" the button that opens the alert. */
   body[data-layout='nerd'] .app-action {
     flex: 1 1 auto;
+    padding: 0;
+    border: 0;
+    font: inherit;
+    cursor: pointer;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -441,6 +446,33 @@
   body[data-layout='nerd'] .app-row-label::before,
   body[data-layout='nerd'] .app-row-value::before {
     content: attr(data-text);
+  }
+
+  /* --- The call alert ------------------------------------------------------------------------- */
+  body[data-layout='nerd'] .app-alert {
+    width: min(270px, calc(100vw - 48px));
+    margin: auto;
+    padding: 0;
+    overflow: hidden;
+    text-align: center;
+  }
+
+  body[data-layout='nerd'] .app-alert-title {
+    margin: 19px 16px 0;
+  }
+
+  body[data-layout='nerd'] .app-alert-message {
+    margin: 3px 16px 19px;
+  }
+
+  body[data-layout='nerd'] .app-alert-actions {
+    display: flex;
+    margin: 0;
+  }
+
+  body[data-layout='nerd'] .app-alert-button {
+    flex: 1;
+    min-height: 44px;
   }
 
   /* --- The bottom bar ------------------------------------------------------------------------- */
@@ -502,8 +534,9 @@
 
 /* Nerd Mode at 390px. The code keeps its line numbers and loses width everywhere else —
    a two-character indent and a narrower gutter — so an achievement three levels deep still gets
-   forty characters a row. The phone follows the window's height and stops at 340px: at a fixed
-   404px it pushed the name below the first screen of a 667px phone. */
+   forty characters a row. The phone is an iPhone 17 Pro Max as large as the screen allows, up to
+   its real width, so its card reads at the sizes it has on a laptop. It fills the first screen, by
+   the candidate's choice: the card carries the name, the role and the ways to reach them. */
 @media screen and (max-width: 768px) {
   body[data-layout='nerd'] {
     --x-line: 20px;
@@ -511,7 +544,7 @@
     --x-number-gap: 10px;
     --x-indent: 2ch;
     --x-code-right: 12px;
-    --x-phone: clamp(240px, 42vh, 340px);
+    --x-phone: calc(min(100vw - 32px, 460px) / 0.4774);
   }
 
   /* The toolbar unpins and gives up its dots: on a phone the switcher needs the whole width. */

--- a/layouts.css
+++ b/layouts.css
@@ -197,6 +197,12 @@
     gap: 8px;
   }
 
+  /* The file's name is chrome, so it is drawn rather than written: a selection of the page starts
+     at the CV, not at a tab. */
+  body[data-layout='nerd'] [data-source-file]::after {
+    content: attr(data-text);
+  }
+
   /* --- The source ----------------------------------------------------------------------------- */
   /* One element per line. The first row of a line starts at its depth; the rows it wraps onto hang
      one indent further in, the way an editor with line wrapping sets a long string, so a wrapped
@@ -277,6 +283,10 @@
     height: var(--x-tabs);
     margin: 0;
     padding: 0 16px;
+  }
+
+  body[data-layout='nerd'] .source-preview-bar span::before {
+    content: attr(data-text);
   }
 
   /* A phone at a phone's proportions. Its padding and radii follow its height, so a shorter window
@@ -385,7 +395,13 @@
     list-style: none;
   }
 
+  body[data-layout='nerd'] .app-actions li {
+    display: flex;
+  }
+
+  /* An action is a link: a tap on "call" calls. */
   body[data-layout='nerd'] .app-action {
+    flex: 1 1 auto;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -454,7 +470,37 @@
   }
 }
 
-/* Nerd Mode at 390px: one column. The code keeps its line numbers and loses width everywhere else —
+/* Nerd Mode below 1000px: one column. Beside a 320px phone the file had thirty characters a row at
+   800px, so the phone moves above the file, and the file's rows stop at a readable measure instead
+   of running the width of a tablet. The phone moves by `order`, which leaves the document order —
+   and a screen reader's — with the file first. */
+@media screen and (max-width: 1000px) {
+  body[data-layout='nerd'] {
+    --x-phone: clamp(300px, 50vh, 440px);
+  }
+
+  body[data-layout='nerd'] .source-view {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  body[data-layout='nerd'] .source-preview {
+    order: -1;
+    position: static;
+    height: auto;
+    overflow: visible;
+    padding: 26px 0 30px;
+  }
+
+  body[data-layout='nerd'] .source-preview-bar {
+    display: none;
+  }
+
+  body[data-layout='nerd'] .source-code {
+    max-width: 100ch;
+  }
+}
+
+/* Nerd Mode at 390px. The code keeps its line numbers and loses width everywhere else —
    a two-character indent and a narrower gutter — so an achievement three levels deep still gets
    forty characters a row. The phone follows the window's height and stops at 340px: at a fixed
    404px it pushed the name below the first screen of a 667px phone. */
@@ -482,24 +528,6 @@
   body[data-layout='nerd'] .layout-switcher a {
     flex: 1 1 0;
     padding: 7px 4px;
-  }
-
-  /* The phone comes first, as the portrait did before. It moves by `order`, which leaves the
-     document order — and a screen reader's — with the file first. */
-  body[data-layout='nerd'] .source-view {
-    grid-template-columns: minmax(0, 1fr);
-  }
-
-  body[data-layout='nerd'] .source-preview {
-    order: -1;
-    position: static;
-    height: auto;
-    overflow: visible;
-    padding: 26px 0 30px;
-  }
-
-  body[data-layout='nerd'] .source-preview-bar {
-    display: none;
   }
 
   body[data-layout='nerd'] .source-tabs {

--- a/locales/de/ui.json
+++ b/locales/de/ui.json
@@ -15,7 +15,13 @@
     "preview": "Vorschau",
     "device": "iPhone",
     "marks": { "profile": "Profil", "contact": "Kontakt" },
-    "card": { "call": "anrufen", "mail": "E-Mail", "location": "Standort" }
+    "card": {
+      "call": "anrufen",
+      "mail": "E-Mail",
+      "callName": "{{value}} anrufen",
+      "mailName": "E-Mail an {{value}}",
+      "location": "Standort"
+    }
   },
   "errors": {
     "loadingTitle": "Lebenslauf konnte nicht geladen werden",

--- a/locales/de/ui.json
+++ b/locales/de/ui.json
@@ -20,6 +20,8 @@
       "mail": "E-Mail",
       "callName": "{{value}} anrufen",
       "mailName": "E-Mail an {{value}}",
+      "callJoke": "Wähl die Nummer doch auf deinem eigenen Handy, du Faulpelz.",
+      "callDismiss": "OK",
       "location": "Standort"
     }
   },

--- a/locales/de/ui.json
+++ b/locales/de/ui.json
@@ -10,6 +10,13 @@
     "profilePhoto": "Porträt von {{name}}",
     "layoutSwitcher": "Lebenslauf-Layout auswählen"
   },
+  "source": {
+    "outline": "Abschnitte",
+    "preview": "Vorschau",
+    "device": "iPhone",
+    "marks": { "profile": "Profil", "contact": "Kontakt" },
+    "card": { "call": "anrufen", "mail": "E-Mail", "location": "Standort" }
+  },
   "errors": {
     "loadingTitle": "Lebenslauf konnte nicht geladen werden",
     "loadingHint": "Weitere Informationen finden Sie in der Konsole."

--- a/locales/en/ui.json
+++ b/locales/en/ui.json
@@ -10,6 +10,13 @@
     "profilePhoto": "Portrait of {{name}}",
     "layoutSwitcher": "Choose CV layout"
   },
+  "source": {
+    "outline": "Sections",
+    "preview": "Preview",
+    "device": "iPhone",
+    "marks": { "profile": "Profile", "contact": "Contact" },
+    "card": { "call": "call", "mail": "mail", "location": "Location" }
+  },
   "errors": {
     "loadingTitle": "Error loading CV",
     "loadingHint": "Please check the console for more details."

--- a/locales/en/ui.json
+++ b/locales/en/ui.json
@@ -15,7 +15,13 @@
     "preview": "Preview",
     "device": "iPhone",
     "marks": { "profile": "Profile", "contact": "Contact" },
-    "card": { "call": "call", "mail": "mail", "location": "Location" }
+    "card": {
+      "call": "call",
+      "mail": "mail",
+      "callName": "Call {{value}}",
+      "mailName": "Email {{value}}",
+      "location": "Location"
+    }
   },
   "errors": {
     "loadingTitle": "Error loading CV",

--- a/locales/en/ui.json
+++ b/locales/en/ui.json
@@ -20,6 +20,8 @@
       "mail": "mail",
       "callName": "Call {{value}}",
       "mailName": "Email {{value}}",
+      "callJoke": "Dial it on your own phone, lazybones.",
+      "callDismiss": "OK",
       "location": "Location"
     }
   },

--- a/print.css
+++ b/print.css
@@ -49,8 +49,10 @@ body {
    HIDE WEB-ONLY ELEMENTS
    ============================================================================= */
 
+/* Nerd Mode's editor is a screen rendering of the same profile; paper prints the base DOM. */
 .print-footer,
-.print-button {
+.print-button,
+.source-view {
   display: none !important;
 }
 

--- a/renderers/SourceRenderer.js
+++ b/renderers/SourceRenderer.js
@@ -6,12 +6,13 @@ import { SwiftSourceLayout } from '../adapters/SwiftSourceLayout.js';
  *
  * Every decision — which lines, which tokens, what is syntax and what is content, what the card
  * shows — is made by `adapters/SwiftSourceLayout.js`. This only turns its output into elements,
- * and keeps the two rules that make the editor safe to read:
+ * and keeps the rules that make the editor safe to read:
  *
  * - Syntax is an empty, `aria-hidden` element whose `data-code` the stylesheet draws, and content
- *   is real text. The line numbers are drawn the same way, from a CSS counter.
- * - The card repeats what the file already says, so it is a picture: `aria-hidden`, and every word
- *   on it drawn from `data-text`. Nobody hears the name twice or copies it out of a phone.
+ *   is real text. The line numbers and the file's name are drawn the same way.
+ * - The card repeats what the file already says, so its words are drawn from `data-text` and kept
+ *   from assistive technology. What looks like a button is one: each action is a link with a name
+ *   of its own, and nothing focusable sits inside anything `aria-hidden` that can be tabbed to.
  */
 export class SourceRenderer extends BaseRenderer {
   constructor(i18n = null, layout = new SwiftSourceLayout()) {
@@ -25,14 +26,15 @@ export class SourceRenderer extends BaseRenderer {
     if (!code || !this.validate(data)) return;
 
     const source = this.layout.compose(data, {
-      t: (key) => (this.i18n ? this.i18n.t(key) : key)
+      t: (key, options) => (this.i18n ? this.i18n.t(key, options) : key)
     });
 
     code.textContent = '';
     source.lines.forEach((line) => code.appendChild(this.createLine(root, line)));
 
     root.querySelectorAll('[data-source-file]').forEach((slot) => {
-      slot.textContent = source.fileName;
+      slot.textContent = '';
+      slot.dataset.text = source.fileName;
     });
 
     this.renderOutline(root, source.outline);
@@ -59,27 +61,40 @@ export class SourceRenderer extends BaseRenderer {
     if (!container) return;
 
     container.textContent = '';
-    container.setAttribute('aria-hidden', 'true');
-    container.appendChild(this.drawn(root, 'p', 'app-name', card.name));
-    if (card.title) container.appendChild(this.drawn(root, 'p', 'app-title', card.title));
+    container.removeAttribute('aria-hidden');
+    container.appendChild(this.drawn(root, 'p', 'app-name', card.name, true));
+    if (card.title) container.appendChild(this.drawn(root, 'p', 'app-title', card.title, true));
 
     if (card.actions.length > 0) {
       const actions = this.createElement(root, 'ul', 'app-actions');
-      card.actions.forEach(({ icon, label }) => {
-        const action = this.drawn(root, 'li', 'app-action', label);
+      card.actions.forEach(({ icon, label, name, href }) => {
+        const action = this.createAddress(root, href);
+        action.classList.add('app-action');
         action.dataset.icon = icon;
-        actions.appendChild(action);
+        action.dataset.text = label;
+        action.setAttribute('aria-label', name);
+        const item = this.createElement(root, 'li');
+        item.appendChild(action);
+        actions.appendChild(item);
       });
       container.appendChild(actions);
     }
 
+    // The details repeat the actions for a pointer; a keyboard and a screen reader already have
+    // the actions, so the rows stay out of both.
     if (card.rows.length > 0) {
       const rows = this.createElement(root, 'ul', 'app-rows');
-      card.rows.forEach(({ kind, label, value }) => {
+      rows.setAttribute('aria-hidden', 'true');
+      card.rows.forEach(({ kind, label, value, href }) => {
         const row = this.createElement(root, 'li', 'app-row');
         row.dataset.kind = kind;
         row.appendChild(this.drawn(root, 'span', 'app-row-label', label));
-        row.appendChild(this.drawn(root, 'span', 'app-row-value', value));
+
+        const detail = href ? this.createAddress(root, href) : this.createElement(root, 'span');
+        detail.classList.add('app-row-value');
+        detail.dataset.text = value;
+        if (href) detail.setAttribute('tabindex', '-1');
+        row.appendChild(detail);
         rows.appendChild(row);
       });
       container.appendChild(rows);
@@ -114,17 +129,28 @@ export class SourceRenderer extends BaseRenderer {
 
     const element =
       token.element === 'a'
-        ? this.createLink(root, token.href, token.text)
+        ? this.createAddress(root, token.href, token.text)
         : this.createElement(root, token.element || 'span');
     element.classList.add('tok', `tok-${token.kind}`);
     element.textContent = token.text;
     return element;
   }
 
+  /** A link to an address: a web page opens in a tab of its own; a mail or a call does not. */
+  createAddress(root, href, text = '') {
+    if (/^https?:/i.test(href)) return this.createLink(root, href, text);
+
+    const link = this.createElement(root, 'a');
+    link.href = href;
+    link.textContent = text;
+    return link;
+  }
+
   /** An element whose words the stylesheet draws from `data-text`. */
-  drawn(root, tag, className, text) {
+  drawn(root, tag, className, text, hidden = false) {
     const element = this.createElement(root, tag, className);
     element.dataset.text = text;
+    if (hidden) element.setAttribute('aria-hidden', 'true');
     return element;
   }
 }

--- a/renderers/SourceRenderer.js
+++ b/renderers/SourceRenderer.js
@@ -1,0 +1,130 @@
+import { BaseRenderer } from './BaseRenderer.js';
+import { SwiftSourceLayout } from '../adapters/SwiftSourceLayout.js';
+
+/**
+ * Writes the CV into Nerd Mode's editor as a Swift file, and its contact card into the phone.
+ *
+ * Every decision — which lines, which tokens, what is syntax and what is content, what the card
+ * shows — is made by `adapters/SwiftSourceLayout.js`. This only turns its output into elements,
+ * and keeps the two rules that make the editor safe to read:
+ *
+ * - Syntax is an empty, `aria-hidden` element whose `data-code` the stylesheet draws, and content
+ *   is real text. The line numbers are drawn the same way, from a CSS counter.
+ * - The card repeats what the file already says, so it is a picture: `aria-hidden`, and every word
+ *   on it drawn from `data-text`. Nobody hears the name twice or copies it out of a phone.
+ */
+export class SourceRenderer extends BaseRenderer {
+  constructor(i18n = null, layout = new SwiftSourceLayout()) {
+    super();
+    this.i18n = i18n;
+    this.layout = layout;
+  }
+
+  render(root, data) {
+    const code = this.getElement(root, 'source-code');
+    if (!code || !this.validate(data)) return;
+
+    const source = this.layout.compose(data, {
+      t: (key) => (this.i18n ? this.i18n.t(key) : key)
+    });
+
+    code.textContent = '';
+    source.lines.forEach((line) => code.appendChild(this.createLine(root, line)));
+
+    root.querySelectorAll('[data-source-file]').forEach((slot) => {
+      slot.textContent = source.fileName;
+    });
+
+    this.renderOutline(root, source.outline);
+    this.renderCard(root, source.card);
+  }
+
+  renderOutline(root, outline) {
+    const container = this.getElement(root, 'source-outline');
+    if (!container) return;
+
+    container.textContent = '';
+    outline.forEach(({ id, label }) => {
+      const link = this.createElement(root, 'a');
+      link.href = `#${id}`;
+      link.textContent = label;
+      const item = this.createElement(root, 'li');
+      item.appendChild(link);
+      container.appendChild(item);
+    });
+  }
+
+  renderCard(root, card) {
+    const container = this.getElement(root, 'source-card');
+    if (!container) return;
+
+    container.textContent = '';
+    container.setAttribute('aria-hidden', 'true');
+    container.appendChild(this.drawn(root, 'p', 'app-name', card.name));
+    if (card.title) container.appendChild(this.drawn(root, 'p', 'app-title', card.title));
+
+    if (card.actions.length > 0) {
+      const actions = this.createElement(root, 'ul', 'app-actions');
+      card.actions.forEach(({ icon, label }) => {
+        const action = this.drawn(root, 'li', 'app-action', label);
+        action.dataset.icon = icon;
+        actions.appendChild(action);
+      });
+      container.appendChild(actions);
+    }
+
+    if (card.rows.length > 0) {
+      const rows = this.createElement(root, 'ul', 'app-rows');
+      card.rows.forEach(({ kind, label, value }) => {
+        const row = this.createElement(root, 'li', 'app-row');
+        row.dataset.kind = kind;
+        row.appendChild(this.drawn(root, 'span', 'app-row-label', label));
+        row.appendChild(this.drawn(root, 'span', 'app-row-value', value));
+        rows.appendChild(row);
+      });
+      container.appendChild(rows);
+    }
+  }
+
+  createLine(root, line) {
+    const element = this.createElement(
+      root,
+      line.heading ? `h${line.heading}` : 'div',
+      'source-line'
+    );
+    element.dataset.depth = String(line.depth);
+    if (line.id) element.id = line.id;
+    if (line.current) element.classList.add('is-current');
+
+    const number = this.createElement(root, 'span', 'source-number');
+    number.setAttribute('aria-hidden', 'true');
+    element.appendChild(number);
+
+    line.tokens.forEach((token) => element.appendChild(this.createToken(root, token)));
+    return element;
+  }
+
+  createToken(root, token) {
+    if ('code' in token) {
+      const syntax = this.createElement(root, 'span', ['tok', `tok-${token.kind}`]);
+      syntax.dataset.code = token.code;
+      syntax.setAttribute('aria-hidden', 'true');
+      return syntax;
+    }
+
+    const element =
+      token.element === 'a'
+        ? this.createLink(root, token.href, token.text)
+        : this.createElement(root, token.element || 'span');
+    element.classList.add('tok', `tok-${token.kind}`);
+    element.textContent = token.text;
+    return element;
+  }
+
+  /** An element whose words the stylesheet draws from `data-text`. */
+  drawn(root, tag, className, text) {
+    const element = this.createElement(root, tag, className);
+    element.dataset.text = text;
+    return element;
+  }
+}

--- a/renderers/SourceRenderer.js
+++ b/renderers/SourceRenderer.js
@@ -12,7 +12,8 @@ import { SwiftSourceLayout } from '../adapters/SwiftSourceLayout.js';
  *   is real text. The line numbers and the file's name are drawn the same way.
  * - The card repeats what the file already says, so its words are drawn from `data-text` and kept
  *   from assistive technology. What looks like a button is one: each action is a link with a name
- *   of its own, and nothing focusable sits inside anything `aria-hidden` that can be tabbed to.
+ *   of its own — or, for "call", a button that opens the alert — and nothing focusable sits inside
+ *   anything `aria-hidden` that can be tabbed to.
  */
 export class SourceRenderer extends BaseRenderer {
   constructor(i18n = null, layout = new SwiftSourceLayout()) {
@@ -39,6 +40,7 @@ export class SourceRenderer extends BaseRenderer {
 
     this.renderOutline(root, source.outline);
     this.renderCard(root, source.card);
+    this.renderAlert(root, source.card.call);
   }
 
   renderOutline(root, outline) {
@@ -67,8 +69,10 @@ export class SourceRenderer extends BaseRenderer {
 
     if (card.actions.length > 0) {
       const actions = this.createElement(root, 'ul', 'app-actions');
-      card.actions.forEach(({ icon, label, name, href }) => {
-        const action = this.createAddress(root, href);
+      card.actions.forEach(({ icon, label, name, href, dialog }) => {
+        const action = dialog
+          ? this.createDialogButton(root, `source-${dialog}`)
+          : this.createAddress(root, href);
         action.classList.add('app-action');
         action.dataset.icon = icon;
         action.dataset.text = label;
@@ -99,6 +103,33 @@ export class SourceRenderer extends BaseRenderer {
       });
       container.appendChild(rows);
     }
+  }
+
+  /** The call alert's words, or none when the profile has no number to joke about. */
+  renderAlert(root, call) {
+    [
+      ['source-call-title', call ? call.title : ''],
+      ['source-call-message', call ? call.message : ''],
+      ['source-call-dismiss', call ? call.dismiss : '']
+    ].forEach(([id, text]) => {
+      const element = this.getElement(root, id);
+      if (element) element.textContent = text;
+    });
+  }
+
+  /** A button that opens a dialog as a modal, so the dialog takes focus and closes on Escape. */
+  createDialogButton(root, id) {
+    const button = this.createElement(root, 'button');
+    button.type = 'button';
+    button.setAttribute('aria-haspopup', 'dialog');
+    button.setAttribute('aria-controls', id);
+    button.addEventListener('click', () => {
+      const dialog = root.getElementById(id);
+      if (!dialog || dialog.open) return;
+      if (typeof dialog.showModal === 'function') dialog.showModal();
+      else dialog.setAttribute('open', '');
+    });
+    return button;
   }
 
   createLine(root, line) {

--- a/script.js
+++ b/script.js
@@ -16,6 +16,7 @@ import { LanguagesRenderer } from './renderers/LanguagesRenderer.js';
 import { CertificationsRenderer } from './renderers/CertificationsRenderer.js';
 import { SocialLinksRenderer } from './renderers/SocialLinksRenderer.js';
 import { InterestsRenderer } from './renderers/InterestsRenderer.js';
+import { SourceRenderer } from './renderers/SourceRenderer.js';
 
 const resolver = new LocaleResolver();
 const locale = resolver.resolve({
@@ -74,6 +75,7 @@ app.registerRenderer('certifications', new CertificationsRenderer());
 app.registerRenderer('skills', new SkillsRenderer());
 app.registerRenderer('languages', new LanguagesRenderer());
 app.registerRenderer('interests', new InterestsRenderer());
+app.registerRenderer('source', new SourceRenderer(i18n));
 
 // Start application
 const currentData = await app.initialize(document);

--- a/tests/PdfExporter.test.js
+++ b/tests/PdfExporter.test.js
@@ -194,7 +194,10 @@ describe('PdfExporter — what has to survive extraction and assistive reading',
   // The web page already skips a missing description. The PDF reserved a paragraph for it anyway,
   // and on spotlight LETTER one reserved line is the difference between two pages and three.
   test('omits a certification description rather than rendering an empty line', () => {
-    const bare = { ...rich, certifications: [{ name: 'iOS Lead Essentials', issuer: 'Academy', year: 2024 }] };
+    const bare = {
+      ...rich,
+      certifications: [{ name: 'iOS Lead Essentials', issuer: 'Academy', year: 2024 }]
+    };
     const definition = new PdfExporter(null, { t: (key) => key }).buildDocument(bare, 'nerd');
     const carriers = [...walk(definition.content)].filter((node) => 'text' in node);
     expect(carriers.length).toBeGreaterThan(0);

--- a/tests/SourceRenderer.test.js
+++ b/tests/SourceRenderer.test.js
@@ -6,6 +6,11 @@ const labels = {
   'source.marks.contact': 'Contact',
   'source.card.mail': 'mail',
   'source.card.mailName': 'Email {{value}}',
+  'source.card.call': 'call',
+  'source.card.callName': 'Call {{value}}',
+  'source.card.callJoke': 'Dial it on your own phone, lazybones.',
+  'source.card.callDismiss': 'OK',
+  'cv:contacts.phone': 'Phone',
   'cv:contacts.email': 'Email',
   'cv:sections.skills': 'Core Technologies',
   'cv:sections.experience': 'Professional Experience',
@@ -44,6 +49,11 @@ describe('SourceRenderer', () => {
         <p aria-hidden="true"><span data-source-file></span></p>
         <div id="source-code"></div>
         <div class="simulator-screen"><img alt="" /><div id="source-card"></div></div>
+        <dialog id="source-call">
+          <h2 id="source-call-title"></h2>
+          <p id="source-call-message"></p>
+          <form method="dialog"><button id="source-call-dismiss"></button></form>
+        </dialog>
       </div>
     </body></html>`).window.document;
   });
@@ -210,6 +220,30 @@ describe('SourceRenderer', () => {
         ];
       })
     ).toEqual([['email', 'Email', 'A', 'mailto:ada@example.com', '-1', 'ada@example.com']]);
+  });
+
+  test('answers a tap on call with an alert: the number, and a nudge to dial it yourself', () => {
+    // The candidate's easter egg. It is a real dialog, so it takes focus, is announced and closes
+    // on Escape, and the button says what it opens.
+    new SourceRenderer(i18n).render(document, { ...profile, phone: '+49 30 1234' });
+
+    const call = document.querySelector('#source-card .app-action[data-icon="phone"]');
+    expect([
+      call.tagName,
+      call.getAttribute('type'),
+      call.getAttribute('aria-haspopup'),
+      call.getAttribute('aria-controls'),
+      call.getAttribute('aria-label'),
+      call.dataset.text
+    ]).toEqual(['BUTTON', 'button', 'dialog', 'source-call', 'Call +49 30 1234', 'call']);
+    expect(document.getElementById('source-call-title').textContent).toBe('+49 30 1234');
+    expect(document.getElementById('source-call-message').textContent).toBe(
+      'Dial it on your own phone, lazybones.'
+    );
+    expect(document.getElementById('source-call-dismiss').textContent).toBe('OK');
+
+    call.click();
+    expect(document.getElementById('source-call').open).toBe(true);
   });
 
   test('renders again without writing the file or the card twice', () => {

--- a/tests/SourceRenderer.test.js
+++ b/tests/SourceRenderer.test.js
@@ -1,0 +1,189 @@
+import { JSDOM } from 'jsdom';
+import { SourceRenderer } from '../renderers/SourceRenderer.js';
+
+const labels = {
+  'source.marks.profile': 'Profile',
+  'source.marks.contact': 'Contact',
+  'source.card.mail': 'mail',
+  'cv:contacts.email': 'Email',
+  'cv:sections.skills': 'Core Technologies',
+  'cv:sections.experience': 'Professional Experience',
+  'cv:sections.languages': 'Languages'
+};
+const i18n = { t: (key) => labels[key] ?? key };
+
+const profile = {
+  name: 'Ada Lovelace',
+  title: 'Senior iOS Engineer',
+  email: 'ada@example.com',
+  social: [{ platform: 'GitHub', url: 'https://github.com/ada' }],
+  skills: [{ category: 'iOS', items: [{ name: 'Swift' }, { name: 'SwiftUI' }] }],
+  relevant_experience: [
+    {
+      title: 'Mobile Engineer',
+      company: 'Acme',
+      location: 'Berlin',
+      period: '2018 – Present',
+      highlights: ['Cut CI time by 75%.']
+    }
+  ],
+  languages: [{ name: 'Italian', level: 'Native' }]
+};
+
+describe('SourceRenderer', () => {
+  let document;
+
+  beforeEach(() => {
+    document = new JSDOM(`<!doctype html><html><body>
+      <div class="source-view" hidden>
+        <ol id="source-outline"></ol>
+        <p aria-hidden="true"><span data-source-file></span></p>
+        <p aria-hidden="true"><span data-source-file></span></p>
+        <div id="source-code"></div>
+        <div class="simulator-screen"><img alt="" /><div id="source-card"></div></div>
+      </div>
+    </body></html>`).window.document;
+  });
+
+  const render = () => new SourceRenderer(i18n).render(document, profile);
+  const code = () => document.getElementById('source-code');
+
+  test('writes the syntax as drawing instructions and the CV as text', () => {
+    render();
+
+    // The stylesheet draws `let`, the quotes and the brackets from `data-code`. Nothing a reader
+    // selects, a screen reader announces or a search matches ever contains them.
+    const syntax = [...code().querySelectorAll('[data-code]')];
+    expect(syntax.length).toBeGreaterThan(20);
+    expect(syntax.every((span) => span.textContent === '')).toBe(true);
+    expect(syntax.every((span) => span.getAttribute('aria-hidden') === 'true')).toBe(true);
+    expect(syntax.map((span) => span.dataset.code)).toEqual(
+      expect.arrayContaining(['let ', 'struct ', '"', 'title: ', '// MARK: - '])
+    );
+
+    expect(code().textContent).toContain('Ada Lovelace');
+    expect(code().textContent).toContain('Cut CI time by 75%.');
+    expect(code().textContent).not.toMatch(/\blet\b|struct|MARK|"|title:/);
+  });
+
+  test('keeps the document outline: the name, the sections and the roles are headings', () => {
+    render();
+
+    expect(code().querySelector('h1').textContent).toBe('Ada Lovelace');
+    expect(
+      [...code().querySelectorAll('h2')].map((heading) => [heading.id, heading.textContent])
+    ).toEqual([
+      ['source-profile', 'Profile'],
+      ['source-contact', 'Contact'],
+      ['source-skills', 'Core Technologies'],
+      ['source-experience', 'Professional Experience'],
+      ['source-languages', 'Languages']
+    ]);
+    expect([...code().querySelectorAll('h3')].map((heading) => heading.textContent)).toEqual([
+      'Mobile Engineer'
+    ]);
+  });
+
+  test('gives each line its depth and marks the one the editor opens on', () => {
+    render();
+
+    const lines = [...code().querySelectorAll('.source-line')];
+    const nameLine = lines.find((line) => line.querySelector('h1'));
+    const highlight = lines.find((line) => line.textContent === 'Cut CI time by 75%.');
+
+    expect(nameLine.dataset.depth).toBe('1');
+    expect(nameLine.classList.contains('is-current')).toBe(true);
+    expect(highlight.dataset.depth).toBe('3');
+    expect(lines.filter((line) => line.classList.contains('is-current'))).toHaveLength(1);
+  });
+
+  test('numbers every line with a counter the reader never selects', () => {
+    render();
+
+    const lines = [...code().querySelectorAll('.source-line')];
+    const numbers = lines.map((line) => line.querySelector('.source-number'));
+    expect(numbers.every((number) => number && number.getAttribute('aria-hidden') === 'true')).toBe(
+      true
+    );
+    expect(numbers.every((number) => number.textContent === '')).toBe(true);
+  });
+
+  test('keeps a link followable, and opens it without handing over the page', () => {
+    render();
+
+    const link = code().querySelector('a');
+    expect(link.textContent).toBe('github.com/ada');
+    expect(link.getAttribute('href')).toBe('https://github.com/ada');
+    expect(link.rel).toBe('noopener noreferrer');
+  });
+
+  test('fills the navigator with a link to every section it wrote', () => {
+    render();
+
+    expect(
+      [...document.querySelectorAll('#source-outline li > a')].map((link) => [
+        link.getAttribute('href'),
+        link.textContent
+      ])
+    ).toEqual([
+      ['#source-profile', 'Profile'],
+      ['#source-contact', 'Contact'],
+      ['#source-skills', 'Core Technologies'],
+      ['#source-experience', 'Professional Experience'],
+      ['#source-languages', 'Languages']
+    ]);
+  });
+
+  test('names the file wherever the editor shows it', () => {
+    render();
+
+    expect(
+      [...document.querySelectorAll('[data-source-file]')].map((slot) => slot.textContent)
+    ).toEqual(['AdaLovelace.swift', 'AdaLovelace.swift']);
+  });
+
+  test('draws the preview as a contact card nobody selects or hears twice', () => {
+    render();
+
+    // The card repeats the name, the role and the address the file already holds as text, so it
+    // is a picture of an app: hidden from assistive technology, and every word drawn from
+    // `data-text` rather than written into the document.
+    const card = document.getElementById('source-card');
+    expect(card.getAttribute('aria-hidden')).toBe('true');
+    expect(card.textContent).toBe('');
+    expect(card.querySelector('.app-name').dataset.text).toBe('Ada Lovelace');
+    expect(card.querySelector('.app-title').dataset.text).toBe('Senior iOS Engineer');
+    expect(
+      [...card.querySelectorAll('.app-action')].map((action) => [
+        action.dataset.icon,
+        action.dataset.text
+      ])
+    ).toEqual([
+      ['mail', 'mail'],
+      ['link', 'GitHub']
+    ]);
+    expect(
+      [...card.querySelectorAll('.app-row')].map((row) => [
+        row.dataset.kind,
+        row.querySelector('.app-row-label').dataset.text,
+        row.querySelector('.app-row-value').dataset.text
+      ])
+    ).toEqual([['email', 'Email', 'ada@example.com']]);
+  });
+
+  test('renders again without writing the file or the card twice', () => {
+    render();
+    const once = code().querySelectorAll('.source-line').length;
+    render();
+
+    expect(code().querySelectorAll('.source-line')).toHaveLength(once);
+    expect(document.querySelectorAll('#source-outline li')).toHaveLength(5);
+    expect(document.querySelectorAll('#source-card .app-name')).toHaveLength(1);
+  });
+
+  test('does nothing on a page without the editor', () => {
+    document.body.innerHTML = '';
+
+    expect(() => render()).not.toThrow();
+  });
+});

--- a/tests/SourceRenderer.test.js
+++ b/tests/SourceRenderer.test.js
@@ -5,12 +5,15 @@ const labels = {
   'source.marks.profile': 'Profile',
   'source.marks.contact': 'Contact',
   'source.card.mail': 'mail',
+  'source.card.mailName': 'Email {{value}}',
   'cv:contacts.email': 'Email',
   'cv:sections.skills': 'Core Technologies',
   'cv:sections.experience': 'Professional Experience',
   'cv:sections.languages': 'Languages'
 };
-const i18n = { t: (key) => labels[key] ?? key };
+const i18n = {
+  t: (key, options = {}) => (labels[key] ?? key).replace('{{value}}', options.value ?? '')
+};
 
 const profile = {
   name: 'Ada Lovelace',
@@ -66,18 +69,27 @@ describe('SourceRenderer', () => {
     expect(code().textContent).not.toMatch(/\blet\b|struct|MARK|"|title:/);
   });
 
-  test('keeps the document outline: the name, the sections and the roles are headings', () => {
+  test('copies a line of names as a list, and a language as a name and its level', () => {
     render();
 
+    const lines = [...code().querySelectorAll('.source-line')].map((line) => line.textContent);
+    expect(lines).toContain('Swift, SwiftUI');
+    expect(lines).toContain('Italian: Native');
+    expect(lines).toContain('GitHub, github.com/ada');
+  });
+
+  test('keeps the document outline: the name first, then the sections and the roles', () => {
+    render();
+
+    expect(code().querySelector('h1, h2, h3').tagName).toBe('H1');
     expect(code().querySelector('h1').textContent).toBe('Ada Lovelace');
     expect(
       [...code().querySelectorAll('h2')].map((heading) => [heading.id, heading.textContent])
     ).toEqual([
-      ['source-profile', 'Profile'],
-      ['source-contact', 'Contact'],
-      ['source-skills', 'Core Technologies'],
       ['source-experience', 'Professional Experience'],
-      ['source-languages', 'Languages']
+      ['source-skills', 'Core Technologies'],
+      ['source-languages', 'Languages'],
+      ['source-contact', 'Contact']
     ]);
     expect([...code().querySelectorAll('h3')].map((heading) => heading.textContent)).toEqual([
       'Mobile Engineer'
@@ -108,13 +120,20 @@ describe('SourceRenderer', () => {
     expect(numbers.every((number) => number.textContent === '')).toBe(true);
   });
 
-  test('keeps a link followable, and opens it without handing over the page', () => {
+  test('keeps a profile link followable, and opens it without handing over the page', () => {
     render();
 
-    const link = code().querySelector('a');
+    const link = code().querySelector('a[href^="https://github.com"]');
     expect(link.textContent).toBe('github.com/ada');
-    expect(link.getAttribute('href')).toBe('https://github.com/ada');
     expect(link.rel).toBe('noopener noreferrer');
+  });
+
+  test('makes the email address a link that writes a mail', () => {
+    render();
+
+    const mail = code().querySelector('a[href="mailto:ada@example.com"]');
+    expect(mail.textContent).toBe('ada@example.com');
+    expect(mail.hasAttribute('target')).toBe(false);
   });
 
   test('fills the navigator with a link to every section it wrote', () => {
@@ -126,49 +145,71 @@ describe('SourceRenderer', () => {
         link.textContent
       ])
     ).toEqual([
-      ['#source-profile', 'Profile'],
-      ['#source-contact', 'Contact'],
-      ['#source-skills', 'Core Technologies'],
       ['#source-experience', 'Professional Experience'],
-      ['#source-languages', 'Languages']
+      ['#source-skills', 'Core Technologies'],
+      ['#source-languages', 'Languages'],
+      ['#source-contact', 'Contact']
     ]);
   });
 
-  test('names the file wherever the editor shows it', () => {
+  test('draws the file name wherever the editor shows it, so a selection starts at the CV', () => {
     render();
 
-    expect(
-      [...document.querySelectorAll('[data-source-file]')].map((slot) => slot.textContent)
-    ).toEqual(['AdaLovelace.swift', 'AdaLovelace.swift']);
+    const slots = [...document.querySelectorAll('[data-source-file]')];
+    expect(slots.map((slot) => slot.dataset.text)).toEqual([
+      'AdaLovelace.swift',
+      'AdaLovelace.swift'
+    ]);
+    expect(slots.every((slot) => slot.textContent === '')).toBe(true);
   });
 
-  test('draws the preview as a contact card nobody selects or hears twice', () => {
+  test('draws the card as a picture, with actions that are real links', () => {
     render();
 
-    // The card repeats the name, the role and the address the file already holds as text, so it
-    // is a picture of an app: hidden from assistive technology, and every word drawn from
-    // `data-text` rather than written into the document.
+    // The card repeats the name, the role and the addresses the file already holds as text, so
+    // its words are drawn from `data-text` and nobody hears them twice. What looks like a button
+    // is one: each action is a link with a name of its own, outside anything `aria-hidden`.
     const card = document.getElementById('source-card');
-    expect(card.getAttribute('aria-hidden')).toBe('true');
+    expect(card.hasAttribute('aria-hidden')).toBe(false);
     expect(card.textContent).toBe('');
-    expect(card.querySelector('.app-name').dataset.text).toBe('Ada Lovelace');
+
+    const name = card.querySelector('.app-name');
+    expect([name.dataset.text, name.getAttribute('aria-hidden')]).toEqual(['Ada Lovelace', 'true']);
     expect(card.querySelector('.app-title').dataset.text).toBe('Senior iOS Engineer');
+
     expect(
       [...card.querySelectorAll('.app-action')].map((action) => [
+        action.tagName,
+        action.getAttribute('href'),
+        action.getAttribute('aria-label'),
         action.dataset.icon,
-        action.dataset.text
+        action.dataset.text,
+        action.closest('[aria-hidden]')
       ])
     ).toEqual([
-      ['mail', 'mail'],
-      ['link', 'GitHub']
+      ['A', 'mailto:ada@example.com', 'Email ada@example.com', 'mail', 'mail', null],
+      ['A', 'https://github.com/ada', 'GitHub', 'link', 'GitHub', null]
     ]);
+  });
+
+  test('keeps the card’s details tappable without reading them out a second time', () => {
+    render();
+
+    const rows = document.querySelector('#source-card .app-rows');
+    expect(rows.getAttribute('aria-hidden')).toBe('true');
     expect(
-      [...card.querySelectorAll('.app-row')].map((row) => [
-        row.dataset.kind,
-        row.querySelector('.app-row-label').dataset.text,
-        row.querySelector('.app-row-value').dataset.text
-      ])
-    ).toEqual([['email', 'Email', 'ada@example.com']]);
+      [...rows.querySelectorAll('.app-row')].map((row) => {
+        const value = row.querySelector('.app-row-value');
+        return [
+          row.dataset.kind,
+          row.querySelector('.app-row-label').dataset.text,
+          value.tagName,
+          value.getAttribute('href'),
+          value.getAttribute('tabindex'),
+          value.dataset.text
+        ];
+      })
+    ).toEqual([['email', 'Email', 'A', 'mailto:ada@example.com', '-1', 'ada@example.com']]);
   });
 
   test('renders again without writing the file or the card twice', () => {
@@ -177,7 +218,7 @@ describe('SourceRenderer', () => {
     render();
 
     expect(code().querySelectorAll('.source-line')).toHaveLength(once);
-    expect(document.querySelectorAll('#source-outline li')).toHaveLength(5);
+    expect(document.querySelectorAll('#source-outline li')).toHaveLength(4);
     expect(document.querySelectorAll('#source-card .app-name')).toHaveLength(1);
   });
 

--- a/tests/SwiftSourceLayout.test.js
+++ b/tests/SwiftSourceLayout.test.js
@@ -1,3 +1,6 @@
+import fs from 'fs';
+import path from 'path';
+import { fileURLToPath } from 'url';
 import { SwiftSourceLayout } from '../adapters/SwiftSourceLayout.js';
 
 const labels = {
@@ -5,6 +8,8 @@ const labels = {
   'source.marks.contact': 'Contact',
   'source.card.call': 'call',
   'source.card.mail': 'mail',
+  'source.card.callName': 'Call {{value}}',
+  'source.card.mailName': 'Email {{value}}',
   'source.card.location': 'Location',
   'cv:contacts.phone': 'Phone',
   'cv:contacts.email': 'Email',
@@ -15,7 +20,7 @@ const labels = {
   'cv:sections.languages': 'Languages',
   'cv:sections.interests': 'Interests'
 };
-const t = (key) => labels[key] ?? key;
+const t = (key, options = {}) => (labels[key] ?? key).replace('{{value}}', options.value ?? '');
 
 const profile = {
   name: 'Ada Lovelace',
@@ -68,6 +73,11 @@ const profile = {
   interests: ['Robotics & IoT', 'Hiking']
 };
 
+const root = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const published = JSON.parse(
+  fs.readFileSync(path.join(root, 'profiles', 'general', 'en.json'), 'utf8')
+);
+
 /** The file as a person reading the editor sees it: syntax and content, four spaces a level. */
 const sourceOf = ({ lines }) =>
   lines
@@ -78,57 +88,36 @@ const sourceOf = ({ lines }) =>
     )
     .join('\n');
 
-/** What survives without the stylesheet: the tokens that carry real text. */
-const contentOf = ({ lines }) =>
-  lines.flatMap((line) =>
-    line.tokens.filter((token) => 'text' in token).map((token) => token.text)
-  );
+/** What a selection of a line copies: its real text, with everything the stylesheet draws gone. */
+const textOf = (line) =>
+  line.tokens
+    .filter((token) => 'text' in token)
+    .map((token) => token.text)
+    .join('');
+
+const textLinesOf = ({ lines }) => lines.map(textOf).filter(Boolean);
 
 describe('SwiftSourceLayout', () => {
   const layout = new SwiftSourceLayout();
 
-  test('reads the CV as a Swift file, section by section, in the order the page renders it', () => {
+  test('reads the CV as a Swift file: who, the profile, the evidence, then how to reach them', () => {
     expect(sourceOf(layout.compose(profile, { t }))).toBe(
       [
-        '//',
         '//  AdaLovelace.swift',
-        '//  CV',
-        '//',
         '',
         'import SwiftUI',
         '',
         'struct AdaLovelace: Engineer {',
-        '    // MARK: - Profile',
-        '',
         '    let name = "Ada Lovelace"',
         '    let title = "Senior iOS Engineer"',
+        '',
+        '    // MARK: - Profile',
+        '',
         '    let focus = "Swift · SwiftUI"',
         '    let summary = """',
         '        Engineer with eleven years in native mobile.',
         '        """',
         '    let availability = "EU citizen"',
-        '',
-        '    // MARK: - Contact',
-        '',
-        '    let contact = Contact(',
-        '        location: "Berlin, Germany",',
-        '        email: "ada@example.com",',
-        '        phone: "+49 30 1234",',
-        '        links: [',
-        '            Link("GitHub", url: "github.com/ada"),',
-        '        ]',
-        '    )',
-        '',
-        '    // MARK: - Core Technologies',
-        '',
-        '    var skills: some SkillSet {',
-        '        Category("iOS") {',
-        '            ["Swift", "SwiftUI"]',
-        '        }',
-        '        Category("Delivery & platform") {',
-        '            ["Fastlane"]',
-        '        }',
-        '    }',
         '',
         '    // MARK: - Professional Experience',
         '',
@@ -151,6 +140,17 @@ describe('SwiftSourceLayout', () => {
         '            summary: "Built AR apps."',
         '        ),',
         '    ]',
+        '',
+        '    // MARK: - Core Technologies',
+        '',
+        '    var skills: some SkillSet {',
+        '        Category("iOS") {',
+        '            ["Swift", "SwiftUI"]',
+        '        }',
+        '        Category("Delivery & platform") {',
+        '            ["Fastlane"]',
+        '        }',
+        '    }',
         '',
         '    // MARK: - Certifications',
         '',
@@ -183,6 +183,17 @@ describe('SwiftSourceLayout', () => {
         '    // MARK: - Interests',
         '',
         '    let interests: [String] = ["Robotics & IoT", "Hiking"]',
+        '',
+        '    // MARK: - Contact',
+        '',
+        '    let contact = Contact(',
+        '        location: "Berlin, Germany",',
+        '        email: "ada@example.com",',
+        '        phone: "+49 30 1234",',
+        '        links: [',
+        '            Link("GitHub", destination: "github.com/ada"),',
+        '        ]',
+        '    )',
         '}',
         '',
         '#Preview {',
@@ -193,29 +204,17 @@ describe('SwiftSourceLayout', () => {
     );
   });
 
-  test('keeps the syntax out of the text: what a reader copies is what the data wrote', () => {
-    // Every keyword, quote, bracket and argument label is decoration the stylesheet draws; the
-    // renderer never writes it into the document. So the real text of the file is the CV and
-    // nothing else — a screen reader, a selection and a search all meet "Acme", not `company:`.
-    expect(contentOf(layout.compose(profile, { t }))).toEqual([
-      'Profile',
+  test('copies line by line the way a reader reads it', () => {
+    // The quotes, brackets and labels are drawn; what separates two words on one line is not.
+    // A selection of the skills reads "Swift, SwiftUI", never "SwiftSwiftUI" — the product review
+    // measured the second in Chrome, and a list of words could not have caught it.
+    expect(textLinesOf(layout.compose(profile, { t }))).toEqual([
       'Ada Lovelace',
       'Senior iOS Engineer',
+      'Profile',
       'Swift · SwiftUI',
       'Engineer with eleven years in native mobile.',
       'EU citizen',
-      'Contact',
-      'Berlin, Germany',
-      'ada@example.com',
-      '+49 30 1234',
-      'GitHub',
-      'github.com/ada',
-      'Core Technologies',
-      'iOS',
-      'Swift',
-      'SwiftUI',
-      'Delivery & platform',
-      'Fastlane',
       'Professional Experience',
       'Mobile Engineer',
       'Acme',
@@ -229,6 +228,11 @@ describe('SwiftSourceLayout', () => {
       'Livorno',
       '2015',
       'Built AR apps.',
+      'Core Technologies',
+      'iOS',
+      'Swift, SwiftUI',
+      'Delivery & platform',
+      'Fastlane',
       'Certifications',
       'iOS Lead Essentials',
       'Essential Developer',
@@ -239,47 +243,63 @@ describe('SwiftSourceLayout', () => {
       'Università di Catania',
       '2009',
       'Languages',
-      'Italian',
-      'Native',
-      'English',
-      'C1 — professional',
+      'Italian: Native',
+      'English: C1 — professional',
       'Interests',
-      'Robotics & IoT',
-      'Hiking'
+      'Robotics & IoT, Hiking',
+      'Contact',
+      'Berlin, Germany',
+      'ada@example.com',
+      '+49 30 1234',
+      'GitHub, github.com/ada'
     ]);
   });
 
-  test('gives the file a document outline: the name, one heading per section, one per role', () => {
+  test('never lets two words on one line meet without real text between them', () => {
+    const glued = layout.compose(published, { t }).lines.flatMap((line) => {
+      const words = line.tokens.filter((token) => 'text' in token);
+      return words
+        .slice(1)
+        .filter((token, index) => token.kind !== 'plain' && words[index].kind !== 'plain')
+        .map((token, index) => `${words[index].text}|${token.text}`);
+    });
+
+    expect(glued).toEqual([]);
+  });
+
+  test('opens on the name: the first heading is the h1, on the line the editor opens on', () => {
+    const { lines } = layout.compose(profile, { t });
+    const headings = lines.flatMap((line) => [
+      ...(line.heading ? [`h${line.heading}`] : []),
+      ...line.tokens.filter((token) => /^h\d$/.test(token.element)).map((token) => token.element)
+    ]);
+
+    expect(headings[0]).toBe('h1');
+    expect(lines.filter((line) => line.current).map((line) => sourceOf({ lines: [line] }))).toEqual(
+      ['    let name = "Ada Lovelace"']
+    );
+  });
+
+  test('gives the file a document outline: one heading per section, one per role', () => {
     const { lines } = layout.compose(profile, { t });
     const tokens = lines.flatMap((line) => line.tokens);
 
-    expect(tokens.filter((token) => token.element === 'h1').map((token) => token.text)).toEqual([
-      'Ada Lovelace'
-    ]);
     expect(
       lines.filter((line) => line.heading === 2).map((line) => [line.id, line.tokens.at(-1).text])
     ).toEqual([
       ['source-profile', 'Profile'],
-      ['source-contact', 'Contact'],
-      ['source-skills', 'Core Technologies'],
       ['source-experience', 'Professional Experience'],
+      ['source-skills', 'Core Technologies'],
       ['source-certifications', 'Certifications'],
       ['source-education', 'Education'],
       ['source-languages', 'Languages'],
-      ['source-interests', 'Interests']
+      ['source-interests', 'Interests'],
+      ['source-contact', 'Contact']
     ]);
     expect(tokens.filter((token) => token.element === 'h3').map((token) => token.text)).toEqual([
       'Mobile Engineer',
       'Intern'
     ]);
-  });
-
-  test('marks the line the editor opens on', () => {
-    const { lines } = layout.compose(profile, { t });
-
-    expect(lines.filter((line) => line.current).map((line) => sourceOf({ lines: [line] }))).toEqual(
-      ['    let name = "Ada Lovelace"']
-    );
   });
 
   test('colours a call apart from a type and an argument label apart from punctuation', () => {
@@ -290,6 +310,7 @@ describe('SwiftSourceLayout', () => {
     expect(kindOf('Engineer')).toBe('type');
     expect(kindOf('KeyValuePairs')).toBe('type');
     expect(kindOf('title: ')).toBe('label');
+    expect(kindOf('destination: ')).toBe('label');
     expect(kindOf('some ')).toBe('keyword');
     expect(kindOf('preferredColorScheme')).toBe('call');
     expect(kindOf('dark')).toBe('property');
@@ -298,24 +319,26 @@ describe('SwiftSourceLayout', () => {
   test('lists the sections it wrote, in order, for the navigator', () => {
     expect(layout.compose(profile, { t }).outline).toEqual([
       { id: 'source-profile', label: 'Profile' },
-      { id: 'source-contact', label: 'Contact' },
-      { id: 'source-skills', label: 'Core Technologies' },
       { id: 'source-experience', label: 'Professional Experience' },
+      { id: 'source-skills', label: 'Core Technologies' },
       { id: 'source-certifications', label: 'Certifications' },
       { id: 'source-education', label: 'Education' },
       { id: 'source-languages', label: 'Languages' },
-      { id: 'source-interests', label: 'Interests' }
+      { id: 'source-interests', label: 'Interests' },
+      { id: 'source-contact', label: 'Contact' }
     ]);
   });
 
-  test('keeps the addresses followable', () => {
+  test('makes every address a link a reader can use: the certificate, mail, phone and profiles', () => {
     const tokens = layout.compose(profile, { t }).lines.flatMap((line) => line.tokens);
 
     expect(
       tokens.filter((token) => token.element === 'a').map((token) => [token.text, token.href])
     ).toEqual([
-      ['github.com/ada', 'https://github.com/ada/'],
-      ['iOS Lead Essentials', 'https://example.com/cert']
+      ['iOS Lead Essentials', 'https://example.com/cert'],
+      ['ada@example.com', 'mailto:ada@example.com'],
+      ['+49 30 1234', 'tel:+49301234'],
+      ['github.com/ada', 'https://github.com/ada/']
     ]);
   });
 
@@ -326,26 +349,36 @@ describe('SwiftSourceLayout', () => {
     expect(sourceOf(source)).not.toMatch(/Certifications|interests|links|focus/);
     expect(source.outline.map((entry) => entry.id)).toEqual([
       'source-profile',
-      'source-contact',
-      'source-skills',
       'source-experience',
+      'source-skills',
       'source-education',
-      'source-languages'
+      'source-languages',
+      'source-contact'
     ]);
   });
 
-  test('composes the contact card the #Preview renders', () => {
+  test('composes the contact card the #Preview renders, with actions that go somewhere', () => {
     expect(layout.compose(profile, { t }).card).toEqual({
       name: 'Ada Lovelace',
       title: 'Senior iOS Engineer',
       actions: [
-        { icon: 'phone', label: 'call' },
-        { icon: 'mail', label: 'mail' },
-        { icon: 'link', label: 'GitHub' }
+        { icon: 'phone', label: 'call', name: 'Call +49 30 1234', href: 'tel:+49301234' },
+        {
+          icon: 'mail',
+          label: 'mail',
+          name: 'Email ada@example.com',
+          href: 'mailto:ada@example.com'
+        },
+        { icon: 'link', label: 'GitHub', name: 'GitHub', href: 'https://github.com/ada/' }
       ],
       rows: [
-        { kind: 'phone', label: 'Phone', value: '+49 30 1234' },
-        { kind: 'email', label: 'Email', value: 'ada@example.com' },
+        { kind: 'phone', label: 'Phone', value: '+49 30 1234', href: 'tel:+49301234' },
+        {
+          kind: 'email',
+          label: 'Email',
+          value: 'ada@example.com',
+          href: 'mailto:ada@example.com'
+        },
         { kind: 'location', label: 'Location', value: 'Berlin, Germany' }
       ]
     });

--- a/tests/SwiftSourceLayout.test.js
+++ b/tests/SwiftSourceLayout.test.js
@@ -1,0 +1,386 @@
+import { SwiftSourceLayout } from '../adapters/SwiftSourceLayout.js';
+
+const labels = {
+  'source.marks.profile': 'Profile',
+  'source.marks.contact': 'Contact',
+  'source.card.call': 'call',
+  'source.card.mail': 'mail',
+  'source.card.location': 'Location',
+  'cv:contacts.phone': 'Phone',
+  'cv:contacts.email': 'Email',
+  'cv:sections.skills': 'Core Technologies',
+  'cv:sections.experience': 'Professional Experience',
+  'cv:sections.certifications': 'Certifications',
+  'cv:sections.education': 'Education',
+  'cv:sections.languages': 'Languages',
+  'cv:sections.interests': 'Interests'
+};
+const t = (key) => labels[key] ?? key;
+
+const profile = {
+  name: 'Ada Lovelace',
+  title: 'Senior iOS Engineer',
+  subtitle: 'Swift · SwiftUI',
+  profile: 'Engineer with eleven years in native mobile.',
+  availability: 'EU citizen',
+  location: 'Berlin, Germany',
+  email: 'ada@example.com',
+  phone: '+49 30 1234',
+  social: [{ platform: 'GitHub', url: 'https://github.com/ada/' }],
+  skills: [
+    { category: 'iOS', items: [{ name: 'Swift' }, { name: 'SwiftUI' }] },
+    { category: 'Delivery & platform', items: [{ name: 'Fastlane' }] }
+  ],
+  relevant_experience: [
+    {
+      title: 'Mobile Engineer',
+      company: 'Acme',
+      location: 'Berlin (remote)',
+      period: 'August 2018 – Present',
+      summary: 'Enterprise mobility.',
+      highlights: ['Cut CI time by 75%.', 'Owned the iOS client.']
+    },
+    {
+      title: 'Intern',
+      company: 'Marte 5',
+      location: 'Livorno',
+      period: '2015',
+      summary: 'Built AR apps.',
+      highlights: []
+    }
+  ],
+  certifications: [
+    {
+      name: 'iOS Lead Essentials',
+      issuer: 'Essential Developer',
+      year: 2024,
+      url: 'https://example.com/cert',
+      description: 'Clean Architecture.'
+    }
+  ],
+  education: [
+    { degree: 'B.Sc. Computer Engineering', school: 'Università di Catania', period: '2009' }
+  ],
+  languages: [
+    { name: 'Italian', level: 'Native' },
+    { name: 'English', level: 'C1 — professional' }
+  ],
+  interests: ['Robotics & IoT', 'Hiking']
+};
+
+/** The file as a person reading the editor sees it: syntax and content, four spaces a level. */
+const sourceOf = ({ lines }) =>
+  lines
+    .map((line) =>
+      line.tokens.length === 0
+        ? ''
+        : '    '.repeat(line.depth) + line.tokens.map((token) => token.code ?? token.text).join('')
+    )
+    .join('\n');
+
+/** What survives without the stylesheet: the tokens that carry real text. */
+const contentOf = ({ lines }) =>
+  lines.flatMap((line) =>
+    line.tokens.filter((token) => 'text' in token).map((token) => token.text)
+  );
+
+describe('SwiftSourceLayout', () => {
+  const layout = new SwiftSourceLayout();
+
+  test('reads the CV as a Swift file, section by section, in the order the page renders it', () => {
+    expect(sourceOf(layout.compose(profile, { t }))).toBe(
+      [
+        '//',
+        '//  AdaLovelace.swift',
+        '//  CV',
+        '//',
+        '',
+        'import SwiftUI',
+        '',
+        'struct AdaLovelace: Engineer {',
+        '    // MARK: - Profile',
+        '',
+        '    let name = "Ada Lovelace"',
+        '    let title = "Senior iOS Engineer"',
+        '    let focus = "Swift · SwiftUI"',
+        '    let summary = """',
+        '        Engineer with eleven years in native mobile.',
+        '        """',
+        '    let availability = "EU citizen"',
+        '',
+        '    // MARK: - Contact',
+        '',
+        '    let contact = Contact(',
+        '        location: "Berlin, Germany",',
+        '        email: "ada@example.com",',
+        '        phone: "+49 30 1234",',
+        '        links: [',
+        '            Link("GitHub", url: "github.com/ada"),',
+        '        ]',
+        '    )',
+        '',
+        '    // MARK: - Core Technologies',
+        '',
+        '    var skills: some SkillSet {',
+        '        Category("iOS") {',
+        '            ["Swift", "SwiftUI"]',
+        '        }',
+        '        Category("Delivery & platform") {',
+        '            ["Fastlane"]',
+        '        }',
+        '    }',
+        '',
+        '    // MARK: - Professional Experience',
+        '',
+        '    let experience: [Role] = [',
+        '        Role(',
+        '            title: "Mobile Engineer",',
+        '            company: "Acme",',
+        '            location: "Berlin (remote)",',
+        '            period: "August 2018 – Present",',
+        '            summary: "Enterprise mobility."',
+        '        ) {',
+        '            "Cut CI time by 75%."',
+        '            "Owned the iOS client."',
+        '        },',
+        '        Role(',
+        '            title: "Intern",',
+        '            company: "Marte 5",',
+        '            location: "Livorno",',
+        '            period: "2015",',
+        '            summary: "Built AR apps."',
+        '        ),',
+        '    ]',
+        '',
+        '    // MARK: - Certifications',
+        '',
+        '    let certifications: [Certification] = [',
+        '        Certification(',
+        '            name: "iOS Lead Essentials",',
+        '            issuer: "Essential Developer",',
+        '            year: 2024,',
+        '            description: "Clean Architecture."',
+        '        ),',
+        '    ]',
+        '',
+        '    // MARK: - Education',
+        '',
+        '    let education: [Degree] = [',
+        '        Degree(',
+        '            title: "B.Sc. Computer Engineering",',
+        '            school: "Università di Catania",',
+        '            period: "2009"',
+        '        ),',
+        '    ]',
+        '',
+        '    // MARK: - Languages',
+        '',
+        '    let languages: KeyValuePairs<String, String> = [',
+        '        "Italian": "Native",',
+        '        "English": "C1 — professional",',
+        '    ]',
+        '',
+        '    // MARK: - Interests',
+        '',
+        '    let interests: [String] = ["Robotics & IoT", "Hiking"]',
+        '}',
+        '',
+        '#Preview {',
+        '    ContactCard(for: AdaLovelace())',
+        '        .preferredColorScheme(.dark)',
+        '}'
+      ].join('\n')
+    );
+  });
+
+  test('keeps the syntax out of the text: what a reader copies is what the data wrote', () => {
+    // Every keyword, quote, bracket and argument label is decoration the stylesheet draws; the
+    // renderer never writes it into the document. So the real text of the file is the CV and
+    // nothing else — a screen reader, a selection and a search all meet "Acme", not `company:`.
+    expect(contentOf(layout.compose(profile, { t }))).toEqual([
+      'Profile',
+      'Ada Lovelace',
+      'Senior iOS Engineer',
+      'Swift · SwiftUI',
+      'Engineer with eleven years in native mobile.',
+      'EU citizen',
+      'Contact',
+      'Berlin, Germany',
+      'ada@example.com',
+      '+49 30 1234',
+      'GitHub',
+      'github.com/ada',
+      'Core Technologies',
+      'iOS',
+      'Swift',
+      'SwiftUI',
+      'Delivery & platform',
+      'Fastlane',
+      'Professional Experience',
+      'Mobile Engineer',
+      'Acme',
+      'Berlin (remote)',
+      'August 2018 – Present',
+      'Enterprise mobility.',
+      'Cut CI time by 75%.',
+      'Owned the iOS client.',
+      'Intern',
+      'Marte 5',
+      'Livorno',
+      '2015',
+      'Built AR apps.',
+      'Certifications',
+      'iOS Lead Essentials',
+      'Essential Developer',
+      '2024',
+      'Clean Architecture.',
+      'Education',
+      'B.Sc. Computer Engineering',
+      'Università di Catania',
+      '2009',
+      'Languages',
+      'Italian',
+      'Native',
+      'English',
+      'C1 — professional',
+      'Interests',
+      'Robotics & IoT',
+      'Hiking'
+    ]);
+  });
+
+  test('gives the file a document outline: the name, one heading per section, one per role', () => {
+    const { lines } = layout.compose(profile, { t });
+    const tokens = lines.flatMap((line) => line.tokens);
+
+    expect(tokens.filter((token) => token.element === 'h1').map((token) => token.text)).toEqual([
+      'Ada Lovelace'
+    ]);
+    expect(
+      lines.filter((line) => line.heading === 2).map((line) => [line.id, line.tokens.at(-1).text])
+    ).toEqual([
+      ['source-profile', 'Profile'],
+      ['source-contact', 'Contact'],
+      ['source-skills', 'Core Technologies'],
+      ['source-experience', 'Professional Experience'],
+      ['source-certifications', 'Certifications'],
+      ['source-education', 'Education'],
+      ['source-languages', 'Languages'],
+      ['source-interests', 'Interests']
+    ]);
+    expect(tokens.filter((token) => token.element === 'h3').map((token) => token.text)).toEqual([
+      'Mobile Engineer',
+      'Intern'
+    ]);
+  });
+
+  test('marks the line the editor opens on', () => {
+    const { lines } = layout.compose(profile, { t });
+
+    expect(lines.filter((line) => line.current).map((line) => sourceOf({ lines: [line] }))).toEqual(
+      ['    let name = "Ada Lovelace"']
+    );
+  });
+
+  test('colours a call apart from a type and an argument label apart from punctuation', () => {
+    const tokens = layout.compose(profile, { t }).lines.flatMap((line) => line.tokens);
+    const kindOf = (code) => tokens.find((token) => token.code === code)?.kind;
+
+    expect(kindOf('Category')).toBe('call');
+    expect(kindOf('Engineer')).toBe('type');
+    expect(kindOf('KeyValuePairs')).toBe('type');
+    expect(kindOf('title: ')).toBe('label');
+    expect(kindOf('some ')).toBe('keyword');
+    expect(kindOf('preferredColorScheme')).toBe('call');
+    expect(kindOf('dark')).toBe('property');
+  });
+
+  test('lists the sections it wrote, in order, for the navigator', () => {
+    expect(layout.compose(profile, { t }).outline).toEqual([
+      { id: 'source-profile', label: 'Profile' },
+      { id: 'source-contact', label: 'Contact' },
+      { id: 'source-skills', label: 'Core Technologies' },
+      { id: 'source-experience', label: 'Professional Experience' },
+      { id: 'source-certifications', label: 'Certifications' },
+      { id: 'source-education', label: 'Education' },
+      { id: 'source-languages', label: 'Languages' },
+      { id: 'source-interests', label: 'Interests' }
+    ]);
+  });
+
+  test('keeps the addresses followable', () => {
+    const tokens = layout.compose(profile, { t }).lines.flatMap((line) => line.tokens);
+
+    expect(
+      tokens.filter((token) => token.element === 'a').map((token) => [token.text, token.href])
+    ).toEqual([
+      ['github.com/ada', 'https://github.com/ada/'],
+      ['iOS Lead Essentials', 'https://example.com/cert']
+    ]);
+  });
+
+  test('leaves out a section with nothing in it, heading and outline entry included', () => {
+    const sparse = { ...profile, certifications: [], interests: [], social: [], subtitle: '' };
+    const source = layout.compose(sparse, { t });
+
+    expect(sourceOf(source)).not.toMatch(/Certifications|interests|links|focus/);
+    expect(source.outline.map((entry) => entry.id)).toEqual([
+      'source-profile',
+      'source-contact',
+      'source-skills',
+      'source-experience',
+      'source-education',
+      'source-languages'
+    ]);
+  });
+
+  test('composes the contact card the #Preview renders', () => {
+    expect(layout.compose(profile, { t }).card).toEqual({
+      name: 'Ada Lovelace',
+      title: 'Senior iOS Engineer',
+      actions: [
+        { icon: 'phone', label: 'call' },
+        { icon: 'mail', label: 'mail' },
+        { icon: 'link', label: 'GitHub' }
+      ],
+      rows: [
+        { kind: 'phone', label: 'Phone', value: '+49 30 1234' },
+        { kind: 'email', label: 'Email', value: 'ada@example.com' },
+        { kind: 'location', label: 'Location', value: 'Berlin, Germany' }
+      ]
+    });
+  });
+
+  test('keeps the card to what the profile has, and to one row of four actions', () => {
+    // A phone screen has room for four buttons across; a fifth would wrap and read as a second
+    // toolbar. So the links fill whatever the call and the mail leave.
+    const social = [
+      { platform: 'GitHub', url: 'https://github.com/ada' },
+      { platform: 'LinkedIn', url: 'https://linkedin.com/in/ada' },
+      { platform: 'Web CV', url: 'https://ada.example.com' }
+    ];
+    const full = layout.compose({ ...profile, social }, { t }).card;
+    const bare = layout.compose({ ...profile, phone: '', location: '', social }, { t }).card;
+    const labelsOf = (card) => card.actions.map((action) => action.label);
+
+    expect(labelsOf(full)).toEqual(['call', 'mail', 'GitHub', 'LinkedIn']);
+    expect(labelsOf(bare)).toEqual(['mail', 'GitHub', 'LinkedIn', 'Web CV']);
+    expect(bare.rows.map((row) => row.kind)).toEqual(['email']);
+  });
+
+  test('names the type after the candidate, as a Swift identifier', () => {
+    const typeOf = (name) => layout.compose({ ...profile, name }, { t }).typeName;
+
+    expect(typeOf('Anna-Lena O’Brien')).toBe('AnnaLenaOBrien');
+    expect(typeOf('José Núñez')).toBe('JoséNúñez');
+    expect(typeOf('')).toBe('Curriculum');
+  });
+
+  test('reads a legacy flat skill list as a plain array', () => {
+    const flat = { ...profile, skills: [{ name: 'Swift' }, { name: 'Git' }] };
+
+    expect(sourceOf(layout.compose(flat, { t }))).toContain(
+      '    let skills: [String] = ["Swift", "Git"]'
+    );
+  });
+});

--- a/tests/SwiftSourceLayout.test.js
+++ b/tests/SwiftSourceLayout.test.js
@@ -9,6 +9,8 @@ const labels = {
   'source.card.call': 'call',
   'source.card.mail': 'mail',
   'source.card.callName': 'Call {{value}}',
+  'source.card.callJoke': 'Dial it on your own phone, lazybones.',
+  'source.card.callDismiss': 'OK',
   'source.card.mailName': 'Email {{value}}',
   'source.card.location': 'Location',
   'cv:contacts.phone': 'Phone',
@@ -358,11 +360,19 @@ describe('SwiftSourceLayout', () => {
   });
 
   test('composes the contact card the #Preview renders, with actions that go somewhere', () => {
+    // "call" is the page's one easter egg, asked for by the candidate: it opens an alert telling
+    // the reader to dial the number themselves. The number stays a tel: link in the file and in
+    // the card's details.
     expect(layout.compose(profile, { t }).card).toEqual({
       name: 'Ada Lovelace',
       title: 'Senior iOS Engineer',
+      call: {
+        title: '+49 30 1234',
+        message: 'Dial it on your own phone, lazybones.',
+        dismiss: 'OK'
+      },
       actions: [
-        { icon: 'phone', label: 'call', name: 'Call +49 30 1234', href: 'tel:+49301234' },
+        { icon: 'phone', label: 'call', name: 'Call +49 30 1234', dialog: 'call' },
         {
           icon: 'mail',
           label: 'mail',
@@ -399,6 +409,7 @@ describe('SwiftSourceLayout', () => {
     expect(labelsOf(full)).toEqual(['call', 'mail', 'GitHub', 'LinkedIn']);
     expect(labelsOf(bare)).toEqual(['mail', 'GitHub', 'LinkedIn', 'Web CV']);
     expect(bare.rows.map((row) => row.kind)).toEqual(['email']);
+    expect(bare.call).toBeNull();
   });
 
   test('names the type after the candidate, as a Swift identifier', () => {


### PR DESCRIPTION
Refs #56.

**Stacked on #64 — merge that first.** With a merge commit this PR then shows only its own three commits; after a squash merge it needs a rebase.

## What it does

On screen, `?layout=nerd` is now an editor:

- **Chrome:** a toolbar with the layout switcher, and a navigator of the file's sections.
- **The file:** the CV as `GiovanniTrovato.swift`. The name and the role open the struct, followed by `// MARK: -` sections for the profile, experience, skills, certifications, education, languages, interests and contact, with line numbers and Swift colouring.
- **The phone:** beside the file, at iPhone 17 Pro Max proportions, running the file's `#Preview`. It shows a contact card with the portrait in a circle, the name and role, call, mail, GitHub and LinkedIn, and the details. At 390px the phone fills the first screen, above the file.
- **The call button:** at the candidate's request it opens an iOS-style alert with the number and "Dial it on your own phone, lazybones." The number stays a `tel:` link in the file and in the card's details.

It replaces the Graphite skin and its arrangement. Impact Spotlight, Technical Profile, print and the PDFs are unchanged.

## How it stays a CV

`adapters/SwiftSourceLayout.js` composes the file and the card from the profile, and `renderers/SourceRenderer.js` only writes them.

- **Syntax is drawn.** Keywords, quotes, brackets, argument labels and line numbers come from CSS, reading `data-code` or a counter on `aria-hidden` elements.
- **What separates two words on a line is real text.** A selection copies "Swift, SwiftUI" and "German: A1 — currently studying".
- **The outline survives.** The name is the `h1`, each section an `h2`, each role an `h3`.
- **The card is a picture with working controls.** Its words are drawn from `data-text`; its actions are real links, and call is a button that opens a modal dialog.
- **Paper is untouched.** The base sections still print, and `.source-view` stays hidden in print and without CSS.

## Verified

- **`npm test`:** 43 suites pass, the formatting check included.
- **`npm run audit:print`:** 12/12 on two pages for all three layouts, and `docs/PRINT_AUDIT.md` comes out unchanged.
- **In Chrome**, at 1440×900, 1280×720, 1024, 800 and 390×844:
  - the current employer sits at 729px at 1440×900;
  - no width scrolls sideways;
  - a navigator jump lands below the pinned bars;
  - the card's type never drops below 11px;
  - the call alert opens as a modal, with focus inside.

## Product review

`cv-reviewer` reviewed the rendered page and requested changes. Its target was "Senior iOS Engineer / Mobile Platform Owner", `general × en`, Germany.

**Fixed on this branch:**

- **Blocking:** words ran together in a copy.
- **Major:**
  - the current employer sat 1.8 to 3.9 screens down;
  - the card's buttons did nothing, and the page had no `mailto:` or `tel:` link anywhere;
  - the card's text came out at 4 to 8px.
- **Minor:**
  - the first heading was not the `h1`;
  - editor chrome ended up in a selection;
  - rows ran to 30 characters at 800px;
  - the link underline was 1.7:1;
  - JetBrains Mono was requested twice.

**Filed as tickets:** #58, #59, #60, #61, #62.

**Deviation from #56's acceptance criteria:** at 390px the file's name line sits below the first screen. By the candidate's choice the phone is drawn at iPhone 17 Pro Max size there, and its card carries the name, the role and the actions on the first screen.

### Observations from the review

- Every string in the file traces to `profiles/general/en.json`; nothing is invented.
- An Xcode look is a relevant signal for an iOS role but adds reading effort for a non-technical screener. `LayoutResolver` defaults to Spotlight, so send the plain URL with applications.
- The page's HTML carries no CV text before JavaScript runs. That predates this branch, and it is why #63 emptied the public page.
- The redesign makes the portrait more prominent; carrying a photo at all was already the candidate's decision.
- The phone number is Italian (+39).
- Not checked: real screen readers, Safari or iOS WebKit, Firefox, and how browser translation treats the CSS-drawn card text.
