### PR TITLE
Retire the closing-keyword exemption list

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -206,12 +206,13 @@ The rule, in full:
   merge closed on its own was read by nobody, and reopening it afterwards leaves a timeline that
   says the work was done twice.
 
-The one exemption is written down where it applies: six commits already merged through pull
-request #31 carry `Closes #15`–`Closes #20`, and rewriting them would orphan the SHAs that pull
-request points at. They are listed in the test by SHA, with the reason, and they will close those
-six tickets when `cv-2026-update` reaches `main` — whoever merges is expected to reopen them.
-Naming the debt is the point: an exemption in a list can be counted, an exemption in a habit
-cannot.
+The one exemption was written down where it applied. Six commits merged through pull request #31
+carried closing keywords for tickets 15 to 20, and rewriting them would have orphaned the SHAs that
+pull request points at, so the test listed them by SHA with the reason. They closed those six
+tickets when #41 merged on 2026-09-10, as #40 said they would, and each was reopened with a note
+naming the commit that closed it. Once all six were on `main` the list exempted nothing and was
+removed: an exemption that can be counted beats one that lives in a habit, and one that exempts
+nothing is noise.
 
 ### Prevention rules become tests where they can
 

--- a/tests/TicketsCloseByHand.test.js
+++ b/tests/TicketsCloseByHand.test.js
@@ -16,24 +16,6 @@ const manifest = JSON.parse(
   readFileSync(new URL('../.agents/harness/ticket-loop.json', import.meta.url))
 );
 
-/**
- * The six commits that carried `Closes #15`–`Closes #20` onto `cv-2026-update` before this rule
- * existed. They are merged already, through pull request #31, so rewriting them would orphan the
- * SHAs that pull request points at — a worse trade than naming the debt.
- *
- * They will close their tickets when `cv-2026-update` reaches `main`. Issue #37 says so, and
- * whoever merges is expected to reopen them for the auditor. Once they are on the base branch
- * they leave the range this check inspects and these lines can be deleted.
- */
-const MERGED_BEFORE_THE_RULE = [
-  '19b19f33fa34b93c08e466803a3229eb3a95b2de', // feat: a lexicon for job adverts — Closes #15
-  'a9f42df263647b88ab84841a83c12591d8e68d6b', // feat: extract what an advert asks for — Closes #16
-  '8ab9a9a92e91dd4d0913ce2ce7dc5fbf741ac733', // feat: separate a layout defect from a gap — Closes #17
-  'ae1b00f470f23812401f26387149f19aa276f7a7', // feat: model a cover letter — Closes #18
-  'e5ea8e381368910b24659776bb4e385d4f92c9eb', // feat: lay out a cover letter on DIN 5008 — Closes #19
-  '8cef3927dfa8bfafa42e80d0da219054239910fd' // feat: generate the letter with the CV — Closes #20
-];
-
 describe('the rule about closing keywords', () => {
   // The check has to be able to fail, and this is where that is proved: a message with the
   // keyword is caught, the same message with `Refs` is not. Without this pair, a predicate that
@@ -61,16 +43,6 @@ describe('a ticket is closed by a person, not by a merge', () => {
     expect(manifest.board.never_autoclose).toBe(true);
   });
 
-  // Full SHAs, and no duplicates. Existence is deliberately not asserted: the objects are only
-  // guaranteed present in a clone that fetched `cv-2026-update`, and a wrong SHA here cannot hide
-  // a violation — it exempts nothing, and the check below goes red naming the commit.
-  test('the exemptions are full SHAs, listed once each', () => {
-    const malformed = MERGED_BEFORE_THE_RULE.filter((sha) => !/^[0-9a-f]{40}$/.test(sha));
-
-    expect(malformed).toEqual([]);
-    expect(new Set(MERGED_BEFORE_THE_RULE).size).toBe(MERGED_BEFORE_THE_RULE.length);
-  });
-
   // The commits this branch would add to the base. On the base branch itself that set is empty
   // and the check passes trivially; on a branch about to be merged it is exactly the history a
   // merge would push to the default branch, which is when GitHub acts on the keywords.
@@ -94,7 +66,6 @@ describe('a ticket is closed by a person, not by a merge', () => {
     const offenders = git('log', '--format=%H', `${ref}..HEAD`)
       .split('\n')
       .filter(Boolean)
-      .filter((sha) => !MERGED_BEFORE_THE_RULE.includes(sha))
       .flatMap((sha) =>
         closingReferences(git('log', '-1', '--format=%B', sha)).map(
           ({ keyword, issue }) => `${sha.slice(0, 7)} ${keyword} #${issue}`


### PR DESCRIPTION
Refs #37, #40.

The closing-keyword check in `tests/TicketsCloseByHand.test.js` carried an exemption list: six commits
that put closing keywords onto `cv-2026-update` before the rule existed. All six have been on `main`
since #41 merged on 2026-09-10, so they can never again fall inside the range the check inspects —
`origin/main..HEAD` — and the list exempted nothing.

- **Removed:** the list, the filter that consulted it, and the test that checked its shape.
- **Kept:** the rule's own tests — every GitHub keyword caught, `Refs` let through — and the check that
  no commit a branch adds closes a ticket.
- **`AGENTS.md`:** the paragraph that said the six tickets *will* close when the branch reaches `main`
  now says what happened: they closed on the merge and were reopened with a note (#40).

`npm test` passes; `prettier --check .` is clean. Nothing the CV renders changes, so no artefact was
rebuilt and no product review applies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
