### PR TITLE
Keep the development server on this machine unless told otherwise

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,6 +20,9 @@ This is a static CV/resume website built with vanilla HTML, CSS, and JavaScript.
 - **Install dependencies**: `npm install`
 - **Serve the site**: `npm run serve` (sends `no-store`; never `python -m http.server` — its
   heuristic caching has hidden real changes more than once)
+- **Serve to another device**: `npm run serve -- --network` (by default the server answers only this
+  machine; hidden paths such as `.git/` are never served, and `applications/` goes only to this machine's
+  own browser — a proxy is recognised by its headers, a raw TCP tunnel is not, so never tunnel the port)
 - **Open CV**: Open `index.html` in a browser (no build step required)
 
 ### Formatting

--- a/scripts/serve.mjs
+++ b/scripts/serve.mjs
@@ -1,9 +1,10 @@
 import { createServer } from 'node:http';
-import { createReadStream } from 'node:fs';
+import { createReadStream, realpath, realpathSync } from 'node:fs';
 import { readdir, readFile, stat } from 'node:fs/promises';
 import { LocalProfiles } from '../core/LocalProfiles.js';
-import { extname, join, normalize, sep } from 'node:path';
+import { extname, isAbsolute, join, normalize, relative, sep } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
+import { promisify } from 'node:util';
 
 /**
  * A development server that refuses to let the browser cache anything.
@@ -21,6 +22,61 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
  * longer. That is a property of the host, not something this file changes.
  */
 const projectRoot = fileURLToPath(new URL('..', import.meta.url));
+
+/**
+ * True for an address on this machine: IPv4 loopback, IPv6 loopback, and IPv4 loopback as a dual-stack
+ * socket reports it. Everything else — a LAN address, a Tailscale address, a missing one — is another
+ * machine.
+ * @param {string|undefined} address - `request.socket.remoteAddress`
+ * @returns {boolean} Whether the request came from this machine
+ */
+export function isLoopback(address) {
+  if (!address) return false;
+  const plain = address.startsWith('::ffff:') ? address.slice('::ffff:'.length) : address;
+  return plain === '::1' || /^127\.\d{1,3}\.\d{1,3}\.\d{1,3}$/.test(plain);
+}
+
+/**
+ * Headers a proxy or tunnel adds for the visitor it forwards. Only their presence counts: the address
+ * they carry is whatever the client wrote, so it can take access away but never grant it.
+ */
+const FORWARDING_HEADERS = ['forwarded', 'via', 'x-forwarded-for', 'x-forwarded-host', 'x-real-ip'];
+
+/**
+ * True for a request this machine's own browser sent directly. Arriving on loopback is not enough: a
+ * tunnel or reverse proxy running here connects from loopback for a visitor elsewhere, and says so in a
+ * header; a page on another site can point its own name at 127.0.0.1 and read what it fetches, and the
+ * name it used is still in Host. So the request must also be addressed to this machine. A relay that
+ * forwards raw bytes adds no header and cannot be told apart: never expose the port through one.
+ * @param {import('node:http').IncomingMessage} request - The request
+ * @returns {boolean} Whether this machine's browser sent it, with nothing in between
+ */
+export function isFromThisMachine({ socket, headers = {} }) {
+  const name = (headers.host || '')
+    .toLowerCase()
+    .replace(/:\d+$/, '')
+    .replace(/^\[(.*)\]$/, '$1');
+  const addressedHere = name === 'localhost' || name.endsWith('.localhost') || isLoopback(name);
+  return (
+    isLoopback(socket?.remoteAddress) &&
+    addressedHere &&
+    !FORWARDING_HEADERS.some((header) => header in headers)
+  );
+}
+
+/**
+ * Where to listen. Loopback by default: this server hands out a tracked repository and, once one
+ * exists, CVs tailored to named employers, which AGENTS.md says leave the machine only as an attached
+ * PDF. Serving other devices on the network — a phone, say — takes `--network`, said out loud.
+ * @param {string[]} args - The command-line arguments after the script
+ * @param {object} env - The environment
+ * @returns {{ port: number, host: string, network: boolean }} The listening settings
+ */
+export function listenSettings(args = [], env = {}) {
+  const network = args.includes('--network');
+  const port = Number(args.find((arg) => /^\d+$/.test(arg)) || env.PORT || 8080);
+  return { port, host: network ? '0.0.0.0' : '127.0.0.1', network };
+}
 
 const types = new Map(
   Object.entries({
@@ -44,6 +100,22 @@ function resolve(url, root) {
   const pathname = decodeURIComponent(new URL(url, 'http://localhost').pathname);
   const target = normalize(join(root, pathname === '/' ? 'index.html' : pathname));
   return target === root.replace(/[\\/]$/, '') || target.startsWith(root) ? target : null;
+}
+
+const realpathOf = promisify(realpath.native);
+
+/**
+ * Whether a path relative to the root may be served; `local` for a request from this machine. A hidden
+ * segment — `.git/`, `.claude/`, `..` — never; `applications/` only locally, compared the way a
+ * filesystem may open it: case-insensitively, and without the trailing dots and spaces Windows drops.
+ * @param {string} path - A path relative to the root, as `path.relative` returns it
+ * @param {boolean} local - Whether the request came from this machine
+ * @returns {boolean} Whether the file may be sent
+ */
+export function mayServe(path, local) {
+  const segments = path.split(sep);
+  if (isAbsolute(path) || segments.some((segment) => segment.startsWith('.'))) return false;
+  return local || segments[0].toLowerCase().replace(/[. ]+$/, '') !== 'applications';
 }
 
 /**
@@ -93,18 +165,58 @@ async function localManifest(root) {
 
 /**
  * Build a static server for `root` that forbids caching.
+ *
+ * Two kinds of path are never handed to just anyone. A hidden path — `.git/`, `.claude/`, any segment
+ * starting with a dot — is never served at all: the page needs none of them, and `.git/` holds the
+ * whole history. `applications/`, and the manifest merged with it, are served only to this machine: a
+ * tailored CV must still preview locally, and must never be readable from another device. Both rules
+ * are checked against the path requested and again against where the file really is, so a link inside
+ * the tree cannot carry a request past them.
  * @param {string} root - Directory to serve
+ * @param {{ isLocal?: (request: import('node:http').IncomingMessage) => boolean }} options - how to
+ *   tell a request from this machine; tests hand in their own
  * @returns {import('node:http').Server} A server, not yet listening
  */
-export function createStaticServer(root = projectRoot) {
+export function createStaticServer(root = projectRoot, { isLocal = isFromThisMachine } = {}) {
+  const realRoot = realpathSync.native(root);
+  const notFound = (response) =>
+    response.writeHead(404, { 'Cache-Control': 'no-store' }).end('Not found');
+  // Where a file really is, when the rules let it be served: a link inside the tree can point into
+  // .git/, into applications/, or out of the tree altogether. Null when it is missing or refused.
+  const servable = async (path, local) => {
+    try {
+      const file = await realpathOf(path);
+      return mayServe(relative(realRoot, file), local) ? file : null;
+    } catch {
+      return null;
+    }
+  };
+
   return createServer(async (request, response) => {
-    const target = resolve(request.url, root);
+    let target;
+    try {
+      target = resolve(request.url, root);
+    } catch {
+      // `/%ZZ` or `//` names no path. Thrown outside the try below, it would take the server down.
+      response.writeHead(400, { 'Cache-Control': 'no-store' }).end('Bad request');
+      return;
+    }
     if (!target) {
       response.writeHead(403).end('Forbidden');
       return;
     }
 
-    if (target === join(root, 'config', 'cv-manifest.json')) {
+    const local = isLocal(request);
+    if (!mayServe(relative(root, target), local)) {
+      notFound(response);
+      return;
+    }
+
+    if (
+      local &&
+      target === join(root, 'config', 'cv-manifest.json') &&
+      (await servable(target, local))
+    ) {
       const body = await localManifest(root);
       if (body !== null) {
         response.writeHead(200, {
@@ -119,24 +231,32 @@ export function createStaticServer(root = projectRoot) {
 
     try {
       const info = await stat(target);
-      const file = info.isDirectory() ? join(target, 'index.html') : target;
-      const size = info.isDirectory() ? (await stat(file)).size : info.size;
+      const file = await servable(info.isDirectory() ? join(target, 'index.html') : target, local);
+      if (!file) {
+        notFound(response);
+        return;
+      }
       response.writeHead(200, {
         'Content-Type': types.get(extname(file)) || 'application/octet-stream',
-        'Content-Length': size,
+        'Content-Length': (await stat(file)).size,
         'Cache-Control': 'no-store, must-revalidate'
       });
       createReadStream(file).pipe(response);
     } catch {
-      response.writeHead(404, { 'Cache-Control': 'no-store' }).end('Not found');
+      notFound(response);
     }
   });
 }
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
-  const port = Number(process.argv[2] || process.env.PORT || 8080);
-  createStaticServer().listen(port, () => {
-    console.log(`serving ${projectRoot} on http://localhost:${port} with no-store`);
+  const { port, host, network } = listenSettings(process.argv.slice(2), process.env);
+  createStaticServer().listen(port, host, () => {
+    console.log(`serving ${projectRoot} on ${host}:${port} with no-store`);
+    console.log(
+      network
+        ? '  open to the network (--network): any device that can reach this machine loads the page; applications/ stays on this machine'
+        : '  this machine only; pass --network to reach another device'
+    );
     console.log(`  http://localhost:${port}/index.html?layout=nerd`);
   });
 }

--- a/tests/DevelopmentServer.test.js
+++ b/tests/DevelopmentServer.test.js
@@ -1,0 +1,258 @@
+/**
+ * @jest-environment node
+ */
+import { mkdirSync, mkdtempSync, rmSync, symlinkSync, writeFileSync } from 'node:fs';
+import { request as httpRequest } from 'node:http';
+import { tmpdir } from 'node:os';
+import { join, sep } from 'node:path';
+import {
+  createStaticServer,
+  isFromThisMachine,
+  isLoopback,
+  listenSettings,
+  mayServe
+} from '../scripts/serve.mjs';
+
+// The development server once listened on every interface and served every file under the root:
+// anyone on the same network — or on a Tailscale network this machine belongs to — could read
+// .git/ and, once an application existed, the tailored CVs and the employers they name (#65).
+// AGENTS.md: a tailored version leaves the machine only as an attached PDF.
+
+describe('who counts as this machine', () => {
+  test.each(['127.0.0.1', '::1', '::ffff:127.0.0.1'])('%s is loopback', (address) => {
+    expect(isLoopback(address)).toBe(true);
+  });
+
+  test.each(['192.168.1.20', '10.0.0.7', '100.101.102.103', '::ffff:192.168.1.20', '', undefined])(
+    '%s is another machine',
+    (address) => {
+      expect(isLoopback(address)).toBe(false);
+    }
+  );
+});
+
+describe('a request from this machine', () => {
+  const arriving = (headers, remoteAddress = '127.0.0.1') => ({
+    socket: { remoteAddress },
+    headers
+  });
+
+  test.each(['localhost:8080', '127.0.0.1:8123', '[::1]:8080', 'cv.localhost:8080', 'LOCALHOST'])(
+    'arrives on loopback addressed to %s',
+    (host) => {
+      expect(isFromThisMachine(arriving({ host }))).toBe(true);
+    }
+  );
+
+  // A page on another site can point its own name at 127.0.0.1; the name it used is still in Host.
+  test.each(['rebound.example:8080', '192.168.1.20:8080', ''])(
+    'addressed to "%s", is not',
+    (host) => {
+      expect(isFromThisMachine(arriving({ host }))).toBe(false);
+    }
+  );
+
+  test.each(['forwarded', 'via', 'x-forwarded-for', 'x-forwarded-host', 'x-real-ip'])(
+    'carrying %s, came through a proxy and is not',
+    (header) => {
+      expect(isFromThisMachine(arriving({ host: 'localhost:8080', [header]: '203.0.113.9' }))).toBe(
+        false
+      );
+    }
+  );
+
+  test('from a LAN address, is not', () => {
+    expect(isFromThisMachine(arriving({ host: 'localhost:8080' }, '192.168.1.20'))).toBe(false);
+  });
+});
+
+describe('which paths may be served', () => {
+  const path = (value) => value.split('/').join(sep);
+
+  test.each(['index.html', 'vendor/fonts/fonts.css', 'config/cv-manifest.json'])(
+    '%s, to anyone',
+    (value) => {
+      expect([mayServe(path(value), false), mayServe(path(value), true)]).toEqual([true, true]);
+    }
+  );
+
+  test.each(['.git/config', 'profiles/.DS_Store', '../outside.txt'])('%s, to nobody', (value) => {
+    expect([mayServe(path(value), false), mayServe(path(value), true)]).toEqual([false, false]);
+  });
+
+  // A case-insensitive filesystem opens Applications/ as applications/, and Windows drops a trailing
+  // dot or space: every spelling that reaches the directory is the directory.
+  test.each([
+    'applications/acme/en.json',
+    'Applications/acme/en.json',
+    'APPLICATIONS/acme/en.json',
+    'applications./acme/en.json',
+    'applications /acme/en.json'
+  ])('%s, to this machine only', (value) => {
+    expect([mayServe(path(value), false), mayServe(path(value), true)]).toEqual([false, true]);
+  });
+
+  test('a path that is not inside the root at all, to nobody', () => {
+    expect(mayServe(join(sep, 'etc', 'passwd'), true)).toBe(false);
+  });
+});
+
+describe('where the server listens', () => {
+  test('on the loopback interface, unless told otherwise', () => {
+    expect(listenSettings([], {})).toEqual({ port: 8080, host: '127.0.0.1', network: false });
+  });
+
+  test('the port still comes from the argument or PORT', () => {
+    expect(listenSettings(['8123'], {}).port).toBe(8123);
+    expect(listenSettings([], { PORT: '9000' }).port).toBe(9000);
+  });
+
+  // Opening the server to the network is a decision, so it takes a word of its own.
+  test('on every interface only with --network', () => {
+    expect(listenSettings(['8123', '--network'], {})).toEqual({
+      port: 8123,
+      host: '0.0.0.0',
+      network: true
+    });
+  });
+});
+
+describe('what the server hands out', () => {
+  let root;
+  let server;
+  let origin;
+
+  const start = async (options) => {
+    server = createStaticServer(root, options);
+    await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    origin = `http://127.0.0.1:${server.address().port}`;
+  };
+  const get = async (path) => {
+    const response = await fetch(`${origin}${path}`);
+    return { status: response.status, body: await response.text() };
+  };
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'serve-'));
+    writeFileSync(join(root, 'index.html'), '<!doctype html><title>CV</title>');
+    mkdirSync(join(root, '.git'));
+    writeFileSync(join(root, '.git', 'config'), '[remote "origin"]\n');
+    mkdirSync(join(root, 'config'));
+    writeFileSync(
+      join(root, 'config', 'cv-manifest.json'),
+      JSON.stringify({
+        defaultProfile: 'general',
+        profiles: { general: { locales: { en: 'profiles/general/en.json' } } }
+      })
+    );
+    mkdirSync(join(root, 'applications', 'acme'), { recursive: true });
+    writeFileSync(join(root, 'applications', 'acme', 'en.json'), '{"name":"tailored for Acme"}');
+  });
+
+  afterEach(async () => {
+    // fetch keeps its connection alive; close it with the server rather than wait out the timeout.
+    server?.closeAllConnections();
+    if (server) await new Promise((resolve) => server.close(resolve));
+    server = null;
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  test('the page itself is served', async () => {
+    await start();
+    expect((await get('/')).status).toBe(200);
+  });
+
+  test('.git is never served, not even to this machine', async () => {
+    await start();
+    expect((await get('/.git/config')).status).toBe(404);
+    expect((await get('/.git/')).status).toBe(404);
+    expect((await get('/%2egit/config')).status).toBe(404);
+  });
+
+  test('this machine still previews a tailored CV', async () => {
+    await start();
+    expect((await get('/applications/acme/en.json')).status).toBe(200);
+    expect((await get('/config/cv-manifest.json')).body).toContain('acme');
+  });
+
+  // A request from another machine cannot be made from a test, so the check that decides it is
+  // handed in: the same server, answering as it would to an address that is not loopback.
+  test('another machine gets neither the applications nor the manifest that lists them', async () => {
+    await start({ isLocal: () => false });
+    expect((await get('/applications/acme/en.json')).status).toBe(404);
+    const manifest = await get('/config/cv-manifest.json');
+    expect(manifest.status).toBe(200);
+    expect(manifest.body).not.toContain('acme');
+  });
+
+  // A raw request, so the test sends what a browser would not: a malformed path, another Host, the
+  // headers a proxy adds.
+  const getAs = (path, headers = {}) =>
+    new Promise((resolve, reject) => {
+      const { port } = server.address();
+      httpRequest({ host: '127.0.0.1', port, path, headers }, (response) => {
+        response.resume();
+        response.on('end', () => resolve(response.statusCode));
+      })
+        .on('error', reject)
+        .end();
+    });
+
+  test('a malformed address is refused, and the next request is still served', async () => {
+    await start();
+    expect(await getAs('/%ZZ')).toBe(400);
+    expect(await getAs('//')).toBe(400);
+    expect((await get('/')).status).toBe(200);
+  });
+
+  // A link inside the tree can point anywhere: what counts is where the file really is, not the name
+  // the request used to reach it.
+  test('a symbolic link reaches neither .git, nor applications from another machine, nor out of the tree', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'outside-'));
+    writeFileSync(join(outside, 'secret.txt'), 'not the site');
+    symlinkSync(join(root, '.git'), join(root, 'history'));
+    symlinkSync(join(root, 'applications', 'acme'), join(root, 'latest'));
+    symlinkSync(outside, join(root, 'elsewhere'));
+    try {
+      await start({ isLocal: () => false });
+      expect((await get('/history/config')).status).toBe(404);
+      expect((await get('/latest/en.json')).status).toBe(404);
+      expect((await get('/elsewhere/secret.txt')).status).toBe(404);
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  test('a directory whose index.html links into .git is not served', async () => {
+    mkdirSync(join(root, 'docs'));
+    symlinkSync(join(root, '.git', 'config'), join(root, 'docs', 'index.html'));
+    await start();
+    expect((await get('/docs/')).status).toBe(404);
+  });
+
+  // The manifest is merged from disk for this machine only, and the file it merges from is held to
+  // the same rules as any other.
+  test('the manifest is not merged from a link that leads to a hidden file', async () => {
+    writeFileSync(join(root, '.private.json'), JSON.stringify({ secret: 'private', profiles: {} }));
+    rmSync(join(root, 'config', 'cv-manifest.json'));
+    symlinkSync(join(root, '.private.json'), join(root, 'config', 'cv-manifest.json'));
+    await start();
+    const manifest = await get('/config/cv-manifest.json');
+    expect(manifest.body).not.toContain('private');
+    expect(manifest.status).toBe(404);
+  });
+
+  // A tunnel or reverse proxy on this machine connects from loopback for a visitor elsewhere, and says
+  // so in a header; a page on another site that points its own name at 127.0.0.1 still sends that
+  // name as Host.
+  test('a request through a proxy, or under another site’s name, is not from this machine', async () => {
+    await start();
+    const { port } = server.address();
+    const tailored = '/applications/acme/en.json';
+    expect(await getAs(tailored, { host: `127.0.0.1:${port}` })).toBe(200);
+    expect(
+      await getAs(tailored, { host: `127.0.0.1:${port}`, 'x-forwarded-for': '203.0.113.9' })
+    ).toBe(404);
+    expect(await getAs(tailored, { host: `rebound.example:${port}` })).toBe(404);
+  });
+});


### PR DESCRIPTION
Refs #65.

## What changes

- **`scripts/serve.mjs`**
  - **Listens on `127.0.0.1`** unless started with `--network`, which binds `0.0.0.0` and says so on startup.
  - **Hidden paths are never served** — `.git/`, `.claude/`, any segment starting with a dot — not even to this machine.
  - **`applications/`, and the manifest merged with it, go only to this machine's own browser**: a request on
    loopback, addressed to `localhost`, `*.localhost` or a loopback address, carrying no forwarding header
    (`Forwarded`, `Via`, `X-Forwarded-For`, `X-Forwarded-Host`, `X-Real-IP`).
  - **Both rules hold against the real path** of the file — a directory's `index.html` and the merged manifest
    included — so a symbolic link cannot carry a request past them; a link out of the tree is refused.
    `applications/` is matched case-insensitively and without trailing dots or spaces.
  - **A malformed address** (`/%ZZ`, `//`) gets a 400. Before, it threw outside the handler's `try` and could stop
    the server.
- **`tests/DevelopmentServer.test.js`** — new.
- **`CLAUDE.md`** — how to serve to another device, and what never leaves this machine.

## Evidence

| Check | Result |
|---|---|
| Real server, default | listens on `127.0.0.1`; the LAN address gets no connection |
| Real server with `--network`, from this machine | page 200; a tailored profile 200; the manifest lists it |
| Real server with `--network`, from the LAN | page 200; the tailored profile 404; the manifest without it |
| From this machine with `X-Forwarded-For`, or with `Host: rebound.example` | the tailored profile 404 |
| A symbolic link to `.git` | 404 from this machine and from the LAN |
| `/%ZZ`, then `//`, then the page | 400, 400, 200 — the server still up |
| `npm test` | 419 passing |
| `npm run verify:pdf` | twelve variants 11/11 |
| `npm run audit:ats` | exit 0; `ATS_AUDIT.md` identical to `main` |
| `npm run audit:print`, whose own server is `createStaticServer` | 12/12 on all three layouts; `PRINT_AUDIT.md` identical to `main` |

## Reviews

- **Adversarial review (Codex): two passes.**
  - **First pass, four findings, all fixed test-first.** A symbolic link passed the lexical checks and was followed
    on read. `Applications/` and `applications./` slipped past a case-sensitive comparison on filesystems that open
    them as `applications/`. A request through a reverse proxy or tunnel on this machine arrived on loopback and
    counted as local. `/%ZZ` and `//` threw before the handler's `try`.
  - **Second pass, two findings.** The merged manifest was read through a link without the real-path check — fixed
    test-first; the test failed with the hidden file's content in the body. A raw TCP tunnel (`ssh -R`, `socat`)
    forwards no header and connects from loopback, so its visitors cannot be told apart from this machine: nothing
    in the request can prove otherwise, and closing it needs a per-run secret, which changes how a preview is
    opened. Filed as **#71**; `CLAUDE.md` and the code say not to tunnel the port.
  - The manifest fix from the second pass was not sent back through Codex.
- **Product review: not needed.** A script, a test and `CLAUDE.md`; nothing the CV says or how it renders.

## Self-review

- `scripts/serve.mjs:115` — a link out of the tree is refused even for this machine. An `applications/` kept
  outside the repository and linked in would no longer preview; nothing like that exists today, and allowing it
  would let any link reach any file. Deliberate.
- `scripts/serve.mjs:54` — a request with no `Host` header (HTTP/1.0) is not from this machine. Browsers always
  send one. No finding.
- The desktop preview opens `http://localhost:<port>` and `audit:print` opens `http://127.0.0.1:<port>`; both count
  as this machine, and `audit:print` passed on this branch. No finding.

**Not fixed here:** #71.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
