### PR TITLE
Run every gate on push and pull request

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -1,0 +1,68 @@
+name: Gates
+
+# Every gate this project has, on every push and every pull request. Until now each ran only when
+# someone remembered to run it, and the audits have already caught defects that shipped for months (#28).
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+# A newer push to the same branch makes the run for the older one moot.
+concurrency:
+  group: gates-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  gates:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          # tests/TicketsCloseByHand.test.js reads every commit the branch adds to origin/main.
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v5
+        with:
+          node-version: 26
+          cache: npm
+
+      # Every audit reads the PDFs through poppler: pdftotext, pdfinfo, pdffonts, pdfimages, pdftoppm.
+      - name: Install poppler
+        run: sudo apt-get update && sudo apt-get install --yes --no-install-recommends poppler-utils
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Formatting
+        run: npm run format:check
+
+      - name: Tests
+        run: npm test
+
+      - name: Generate and audit the twelve PDF variants
+        run: npm run verify:pdf
+
+      - name: Audit what a stranger's parser recovers
+        run: npm run audit:ats
+
+      # audit-print exits 2 and checks nothing when it finds no browser. Any exit but 0 fails the step,
+      # so an audit that did not run can never read as a pass. The runner image ships Chrome.
+      - name: Audit what the browser prints
+        run: npm run audit:print
+        env:
+          CHROME_PATH: /usr/bin/google-chrome
+
+      - name: Keep the reports the audits wrote
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: audit-reports
+          path: |
+            docs/PDF_AUDIT.md
+            docs/ATS_AUDIT.md
+            docs/PRINT_AUDIT.md
+          if-no-files-found: ignore

--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -25,6 +25,11 @@ jobs:
           # tests/TicketsCloseByHand.test.js reads every commit the branch adds to origin/main.
           fetch-depth: 0
 
+      # The reports are tracked, so a run that stops before an audit would upload the committed ones as
+      # if this run had written them. Everything an audit writes from here on is newer than this mark.
+      - name: Mark the start of the run
+        run: touch "$RUNNER_TEMP/run-started"
+
       - uses: actions/setup-node@v5
         with:
           node-version: 26
@@ -56,13 +61,17 @@ jobs:
         env:
           CHROME_PATH: /usr/bin/google-chrome
 
-      - name: Keep the reports the audits wrote
+      - name: Collect the reports this run wrote
+        if: always()
+        run: |
+          mkdir -p "$RUNNER_TEMP/audit-reports"
+          find docs -maxdepth 1 -name '*_AUDIT.md' -newer "$RUNNER_TEMP/run-started" -exec cp {} "$RUNNER_TEMP/audit-reports/" \;
+          ls "$RUNNER_TEMP/audit-reports"
+
+      - name: Keep them
         if: always()
         uses: actions/upload-artifact@v5
         with:
           name: audit-reports
-          path: |
-            docs/PDF_AUDIT.md
-            docs/ATS_AUDIT.md
-            docs/PRINT_AUDIT.md
+          path: ${{ runner.temp }}/audit-reports/
           if-no-files-found: ignore


### PR DESCRIPTION
Refs #28.

## What changes

- **`.github/workflows/gates.yml`** — new. On every push, every pull request, and on demand: formatting, `npm test`,
  `npm run verify:pdf` (the twelve PDF variants and their audit), `npm run audit:ats`, and `npm run audit:print` in
  the runner's Chrome, after installing poppler. The three reports are kept as a run artefact, pass or fail.
  - `fetch-depth: 0`, because `tests/TicketsCloseByHand.test.js` reads the commits a branch adds to `origin/main`.
  - A read-only token; a newer push to the same ref cancels the older run.

## Evidence: a red build is possible, and the green one is real

| Run | Commit | Result |
|---|---|---|
| [34634153609](https://github.com/PigLardLord/cv-giovanni/actions/runs/34634153609) | `87737dc`, this branch | success on every step |
| [34634461360](https://github.com/PigLardLord/cv-giovanni/actions/runs/34634461360) | `a0f24ff`, a throwaway branch that printed the role line white on white | **failure at "Audit what the browser prints"**: Impact Spotlight and Technical Profile 11/12 on `contrast`, every word of the role line at 1:1. Formatting, the tests, the PDF audit and the ATS audit all passed — the build went red on the audit and nowhere else |
| [34655764224](https://github.com/PigLardLord/cv-giovanni/actions/runs/34655764224) | `1a18544`, the review's fix | success; the artifact holds only the reports that run wrote |

The throwaway branch is deleted; the run keeps its commit.

**The exit-2 rule.** `audit-print` exits 2 when it finds no browser. A step fails on any exit but 0, and no step sets
`continue-on-error`, so an audit that did not run fails the job.

## Reviews

- **Adversarial review (Codex): ran, one finding, fixed.** The reports are tracked, so a run that stopped before an
  audit uploaded the committed ones as if it had written them, old scores included. A mark taken right after checkout
  now decides, and only reports newer than it are kept; run 34655764224 below is that version. The fix was not sent back
  through Codex: its limit resets on 15 September, and a second pass is queued for then.
- **Product review: not needed.** Build tooling only; nothing the CV says or how it renders.

## Self-review

- `.github/workflows/gates.yml:6` — `push` on every branch and `pull_request` both fire for a branch with an
  open pull request: one run on the branch, one on its merge with `main`. They answer different questions, for a
  few minutes of runner time. No finding.
- `.github/workflows/gates.yml:30` — Node 26 is what the gates have run on so far; nothing in the repository
  pins a version and `package.json` has no `engines`. No finding, but worth pinning when another machine joins.
- Pull requests opened before this merges carry no workflow until they are rebased onto `main`.
- It does not deploy: #45 builds on this once #44 has chosen the branching model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

