### PR TITLE
Date the cover letter from the city, not the full address

### DIFF
--- a/adapters/LetterLayout.js
+++ b/adapters/LetterLayout.js
@@ -1,3 +1,5 @@
+import { PlaceLexicon } from '../domain/PlaceLexicon.js';
+
 /**
  * A cover letter on a page, laid out to DIN 5008 form B.
  *
@@ -118,8 +120,10 @@ export class LetterLayout {
             month: 'long',
             day: 'numeric'
           }).format(parsed);
+      // Dated from the city alone, as a German reader expects: the region and the country are in the
+      // sender line already (#36).
       stack.push({
-        text: [identity.location, formatted].filter(Boolean).join(', '),
+        text: [PlaceLexicon.cityOf(identity.location), formatted].filter(Boolean).join(', '),
         alignment: 'right'
       });
     }

--- a/domain/PlaceLexicon.js
+++ b/domain/PlaceLexicon.js
@@ -153,4 +153,23 @@ export class PlaceLexicon {
     if (parts.length < 2 || parts.length > 4) return null;
     return PlaceLexicon.recognise(parts[parts.length - 1]) ? text : null;
   }
+
+  /**
+   * The city alone, for the line that dates a letter: `Bad Liebenstein, Thuringia, Germany` is
+   * `Bad Liebenstein`, because a German letter is dated from the place, not from the address.
+   *
+   * Only when every part after the first is a region or a country this list knows. Otherwise the
+   * location comes back as written: an unknown part could be the city's region or the city itself,
+   * and a letter dated from the wrong one is worse than a letter dated from all of it.
+   * @param {string} location - A location as the CV writes it
+   * @returns {string} The city, or the location unchanged when that cannot be told
+   */
+  static cityOf(location) {
+    const text = String(location ?? '').trim();
+    const [city, ...rest] = text.split(',').map((part) => part.trim());
+    const places = ['countries', 'regions'];
+    const known =
+      rest.length > 0 && rest.every((part) => places.includes(PlaceLexicon.recognise(part)?.kind));
+    return city && known ? city : text;
+  }
 }

--- a/domain/PlaceLexicon.js
+++ b/domain/PlaceLexicon.js
@@ -161,6 +161,8 @@ export class PlaceLexicon {
    * Only when every part after the first is a region or a country this list knows. Otherwise the
    * location comes back as written: an unknown part could be the city's region or the city itself,
    * and a letter dated from the wrong one is worse than a letter dated from all of it.
+   * A first part that is a country (`Germany, Berlin`) or carries a number (`Musterstraße 1, Berlin`)
+   * is not a city either, so that location comes back as written too.
    * @param {string} location - A location as the CV writes it
    * @returns {string} The city, or the location unchanged when that cannot be told
    */
@@ -170,6 +172,8 @@ export class PlaceLexicon {
     const places = ['countries', 'regions'];
     const known =
       rest.length > 0 && rest.every((part) => places.includes(PlaceLexicon.recognise(part)?.kind));
-    return city && known ? city : text;
+    const cityLike =
+      Boolean(city) && !/\d/.test(city) && PlaceLexicon.recognise(city)?.kind !== 'countries';
+    return cityLike && known ? city : text;
   }
 }

--- a/tests/LetterLayout.test.js
+++ b/tests/LetterLayout.test.js
@@ -145,6 +145,26 @@ describe('the date is formatted, never spelled', () => {
     expect(german).toMatch(/9\. September 2026/);
   });
 
+  // A German letter is dated from the city alone. The region and the country belong in the sender
+  // line, which keeps the whole location (#36).
+  test('dates the letter from the city, and leaves the whole location to the sender', () => {
+    const lines = flatten(
+      new LetterLayout().compose(new CoverLetter(letter), {
+        identity: { ...identity, location: 'Bad Liebenstein, Thuringia, Germany' },
+        format,
+        theme,
+        typography,
+        t,
+        locale: 'de'
+      }).content
+    );
+
+    expect(lines).toContain('Bad Liebenstein, 9. September 2026');
+    expect(lines.some((line) => line.includes('· Bad Liebenstein, Thuringia, Germany ·'))).toBe(
+      true
+    );
+  });
+
   test('an unparseable date is printed as written rather than dropped', () => {
     expect(flatten(compose({ ...letter, date: 'next Tuesday' }).content).join('\n')).toContain(
       'next Tuesday'

--- a/tests/PlaceLexicon.test.js
+++ b/tests/PlaceLexicon.test.js
@@ -18,6 +18,10 @@ describe('the city a location names, for the line that dates a letter', () => {
     'Pisa, Tuscany, Italy',
     'Musterstraße 1, Bad Liebenstein, Germany',
     'Remote, Europe',
+    // Found by the adversarial review: a country written first is not a city, and a first part with a
+    // number in it is an address, even when every part after it is a place the lexicon knows.
+    'Germany, Berlin',
+    'Musterstraße 1, Berlin, Deutschland',
     ''
   ])('"%s" comes back as written', (location) => {
     expect(PlaceLexicon.cityOf(location)).toBe(location);

--- a/tests/PlaceLexicon.test.js
+++ b/tests/PlaceLexicon.test.js
@@ -1,0 +1,25 @@
+import { PlaceLexicon } from '../domain/PlaceLexicon.js';
+
+describe('the city a location names, for the line that dates a letter', () => {
+  test.each([
+    ['Bad Liebenstein, Thuringia, Germany', 'Bad Liebenstein'],
+    ['Bad Liebenstein, Thüringen, Deutschland', 'Bad Liebenstein'],
+    ['Munich, Bavaria, Germany', 'Munich'],
+    // Berlin is a state as well as a city: the first part is the city, whatever else it names.
+    ['Berlin, Germany', 'Berlin']
+  ])('%s is dated from %s', (location, city) => {
+    expect(PlaceLexicon.cityOf(location)).toBe(city);
+  });
+
+  // When a part after the first is not a region or a country the list knows, nothing tells a
+  // city's region from a street and its city, so the location stays as written.
+  test.each([
+    'Bad Liebenstein',
+    'Pisa, Tuscany, Italy',
+    'Musterstraße 1, Bad Liebenstein, Germany',
+    'Remote, Europe',
+    ''
+  ])('"%s" comes back as written', (location) => {
+    expect(PlaceLexicon.cityOf(location)).toBe(location);
+  });
+});


### PR DESCRIPTION
Refs #36.

## What changes

- **`domain/PlaceLexicon.js`** — `cityOf(location)`: the first comma-separated part, when every part after it is a
  region or a country the lexicon knows; otherwise the location exactly as written. `Bad Liebenstein, Thuringia,
  Germany` is `Bad Liebenstein`; `Berlin, Germany` is `Berlin`, though Berlin is also a state; `Pisa, Tuscany,
  Italy` stays whole, because the lexicon does not know Tuscany and cannot tell a region from a district.
- **`adapters/LetterLayout.js`** — the place-and-date line uses it. The sender line keeps the whole location.
- **`tests/PlaceLexicon.test.js`** — new, eleven cases. **`tests/LetterLayout.test.js`** — the German date line from a
  full location, and the sender line still whole.

## Evidence

| Check | Result |
|---|---|
| A cover letter built from a scratch profile under `applications/`, location `Bad Liebenstein, Thuringia, Germany` | before: `Bad Liebenstein, Thuringia, Germany, September 9, 2026`; after: `Bad Liebenstein, September 9, 2026`. The sender line still reads `Giovanni Trovato · Bad Liebenstein, Thuringia, Germany · …` |
| `audit:pdf` on that application | exit 0 — 12 cover letters 6/6, 12 CV variants 11/11 |
| `npm test` | 384 passing |
| `npm run verify:pdf` | twelve variants 11/11; `PDF_AUDIT.md` identical to `main` |
| `npm run audit:ats` | Recoverability 80/80; `ATS_AUDIT.md` identical to `main` |
| `npm run audit:print` | 12/12 on all three layouts; `PRINT_AUDIT.md` identical to `main` |

The published profile carries no letter, so nothing generated from `profiles/` changes.

## Reviews

- **Adversarial review (Codex): ran, two findings, both fixed test-first.** `Germany, Berlin` dated the letter from
  the country, and `Musterstraße 1, Berlin, Deutschland` from the street, because every part after the first was a
  place the lexicon knows. A first part that is a country, or that carries a number, now leaves the location as
  written. Both cases failed first. The fix was not sent back through Codex: its limit resets on 15 September, and
  a second pass is queued for then.
- **Product review: skipped, deliberately.** It reviews the CV, and the CV did not change. The letter changes by one
  line, to the convention the ticket names, checked in the extracted text above.

## Self-review

- `domain/PlaceLexicon.js:167` — a location the lexicon cannot fully account for comes back whole. A German letter
  dated `Pisa, Tuscany, Italy, 9. September 2026` is not the convention, but it is not wrong, and a trimmed guess
  could be. No finding.
- A location written country first, or with a street before the city, comes back whole too: the review found both
  slipping through when the rest of the location was known, and both are tests now. No finding.

**Found in passing:** the first scratch profile was named `zz-letter`, and every A4 file failed `audit:pdf`'s
format check — on `main` as here — because the audit looks for `-letter-` anywhere in a filename. Filed as #79.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

