### PR TITLE
Carry the profile's interests in the CV model

### DIFF
--- a/domain/CvDocument.js
+++ b/domain/CvDocument.js
@@ -19,5 +19,6 @@ export class CvDocument {
     this.education = data.education || [];
     this.languages = data.languages || [];
     this.certifications = data.certifications || [];
+    this.interests = data.interests || [];
   }
 }

--- a/tests/CvDocument.test.js
+++ b/tests/CvDocument.test.js
@@ -14,3 +14,13 @@ test('maps source data into a framework-free document model', () => {
   expect(model.skills[0].category).toBe('iOS');
   expect(model.experience).toEqual([]);
 });
+
+// Interests are part of the CV like every other section. The model carries them, so every output
+// boundary built on it can reach them, whether or not it shows them (#35).
+test('carries the interests the profile writes, and none when it writes none', () => {
+  expect(new CvDocument({ interests: ['Mountain Hiking', 'Tech Mentoring'] }).interests).toEqual([
+    'Mountain Hiking',
+    'Tech Mentoring'
+  ]);
+  expect(new CvDocument({}).interests).toEqual([]);
+});


### PR DESCRIPTION
Refs #35.

## What changes

- **`domain/CvDocument.js`** — the model carries `interests`, as it carries every other section: the list the profile
  writes, or none.
- **`tests/CvDocument.test.js`** — a case for both.

`renderers/InterestsRenderer.js` keeps reading the profile, because every renderer on the page does. The ticket's
premise, that interests alone bypass the model, turned out half right; the comment on #35 says why, and the rest is
#81.

## Evidence

| Check | Result |
|---|---|
| The new test, before the change | failed: `interests` was `undefined` |
| `npm test` | 373 passing |
| `npm run verify:pdf` | twelve variants 11/11; `PDF_AUDIT.md` identical to `main` |
| `npm run audit:ats` | Recoverability 80/80; `ATS_AUDIT.md` identical to `main` — the audit reads the model's fields by name, so a new one changes nothing there |

## Reviews

- **Adversarial review (Codex): ran, no defects.** `codex exec` in a read-only sandbox over the branch's commits
  against `main` returned `NO DEFECTS`.
- **Product review: not needed.** Nothing the CV says or how it renders changes: no boundary shows interests from the
  model yet.

## Self-review

- `domain/CvDocument.js:22` — the list passes through as written, like `skills` and `languages`; the page's
  trimming stays in its renderer. No finding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

