### PR TITLE
Read a PDF's paper and kind from the end of its name

### DIFF
--- a/scripts/audit-pdfs.mjs
+++ b/scripts/audit-pdfs.mjs
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { GenerationTarget } from '../core/GenerationTarget.js';
 import { readableAddress } from '../domain/ReadableUrl.js';
 import { CoverLetter } from '../domain/CoverLetter.js';
+import { pdfVariant } from './lib/pdf-variant.mjs';
 
 const projectRoot = new URL('../', import.meta.url);
 // The expectations come from the CV under test, not from the published one. Auditing a
@@ -152,7 +153,7 @@ function highlightsIntact(collapsed) {
 // chronology, no skills and no second page, so every structural check written for a CV would
 // fail on a perfectly good one. The `-letter` in the name is the signal, which is why
 // LetterExporter puts it there.
-const isCoverLetter = (filename) => /-cover(-|\.)/.test(filename);
+const isCoverLetter = (filename) => pdfVariant(filename).coverLetter;
 const letter = profile.letter ? new CoverLetter(profile.letter) : null;
 
 for (const filename of pdfFiles) {
@@ -160,7 +161,9 @@ for (const filename of pdfFiles) {
   const info = execFileSync('pdfinfo', [path], { encoding: 'utf8' });
   const extracted = execFileSync('pdftotext', [path, '-'], { encoding: 'utf8' });
   const imageList = execFileSync('pdfimages', ['-list', path], { encoding: 'utf8' });
-  const expectedLetter = filename.includes('-letter-');
+  // Read from the end of the name: a profile named with `letter` in it used to make every file
+  // US Letter (#79).
+  const expectedLetter = pdfVariant(filename).paper === 'letter';
   const sizeOk = expectedLetter ? /612 x 792 pts/.test(info) : /595\.28 x 841\.89 pts/.test(info);
   const pages = Number(info.match(/Pages:\s+(\d+)/)?.[1]);
   const pageTwo =

--- a/scripts/lib/pdf-variant.mjs
+++ b/scripts/lib/pdf-variant.mjs
@@ -1,0 +1,23 @@
+/**
+ * The paper and the kind of document a generated PDF is, read from the end of its name.
+ *
+ * `core/PdfExporter.js` and `core/LetterExporter.js` end every variant's name the same way:
+ * `-<layout>[-cover]-<a4|letter>-<color|monochrome>.pdf`. The name begins with the profile, and a
+ * profile can be named with the very words a variant is made of — an application called `zz-letter`
+ * made every A4 file look like US Letter to a check that searched the whole name (#79). So only the
+ * end is read.
+ */
+const ENDING = /-(cover-)?(a4|letter)-(color|monochrome)\.pdf$/;
+
+/**
+ * @param {string} filename - A generated variant's filename
+ * @returns {{ paper: 'a4'|'letter', coverLetter: boolean }} What the name says the file is
+ * @throws {Error} When the name does not end the way the exporters end it: guessing is how #79 happened
+ */
+export function pdfVariant(filename) {
+  const match = ENDING.exec(filename);
+  if (!match) {
+    throw new Error(`${filename} does not end in -<a4|letter>-<color|monochrome>.pdf`);
+  }
+  return { paper: match[2], coverLetter: Boolean(match[1]) };
+}

--- a/tests/PdfVariant.test.js
+++ b/tests/PdfVariant.test.js
@@ -1,0 +1,44 @@
+import { pdfVariant } from '../scripts/lib/pdf-variant.mjs';
+
+describe('the paper and the kind of document a generated PDF is, read from the end of its name', () => {
+  test.each([
+    ['giovanni-trovato-general-en-nerd-a4-color.pdf', { paper: 'a4', coverLetter: false }],
+    [
+      'giovanni-trovato-general-en-spotlight-letter-monochrome.pdf',
+      { paper: 'letter', coverLetter: false }
+    ],
+    ['giovanni-trovato-general-en-nerd-cover-a4-color.pdf', { paper: 'a4', coverLetter: true }],
+    [
+      'giovanni-trovato-general-en-technical-cover-letter-monochrome.pdf',
+      { paper: 'letter', coverLetter: true }
+    ]
+  ])('%s', (filename, variant) => {
+    expect(pdfVariant(filename)).toEqual(variant);
+  });
+
+  // A profile's name comes first in the filename, and it can be made of the very words the variant is
+  // made of. Measured: an application named zz-letter failed the format check on every A4 file (#79).
+  test.each([
+    ['giovanni-trovato-zz-letter-en-nerd-a4-color.pdf', { paper: 'a4', coverLetter: false }],
+    [
+      'giovanni-trovato-zz-letter-en-nerd-cover-a4-monochrome.pdf',
+      { paper: 'a4', coverLetter: true }
+    ],
+    [
+      'giovanni-trovato-cover-letter-en-spotlight-a4-color.pdf',
+      { paper: 'a4', coverLetter: false }
+    ],
+    [
+      'giovanni-trovato-cover-en-technical-letter-color.pdf',
+      { paper: 'letter', coverLetter: false }
+    ]
+  ])('a profile named with those words changes nothing: %s', (filename, variant) => {
+    expect(pdfVariant(filename)).toEqual(variant);
+  });
+
+  test('a name that does not end in a paper and a colour mode is refused, not guessed', () => {
+    expect(() => pdfVariant('giovanni-trovato-general-en-nerd.pdf')).toThrow(
+      /giovanni-trovato-general-en-nerd\.pdf/
+    );
+  });
+});


### PR DESCRIPTION
Refs #79.

## What changes

- **`scripts/lib/pdf-variant.mjs`** — new. `pdfVariant(filename)` reads the paper and whether the file is a cover
  letter from the ending `core/PdfExporter.js` and `core/LetterExporter.js` give every variant,
  `-<layout>[-cover]-<a4|letter>-<color|monochrome>.pdf`, and refuses a name that does not end that way.
- **`scripts/audit-pdfs.mjs`** — `isCoverLetter` and the expected paper both come from it. `isCoverLetter` keeps its
  name, because #76 (#53) calls it.
- **`tests/PdfVariant.test.js`** — new, nine cases; four of them are profiles named with the words a variant is made
  of.

## Evidence

| Check | Result |
|---|---|
| `applications/zz-letter/en.json` — the general profile plus a letter — audited on `main` | exit 1: all twelve A4 files fail `format`, the CV variants at 10/11 and the A4 cover letters at 5/6 |
| The same profile on this branch | exit 0: twelve CV variants 11/11, twelve cover letters 6/6 |
| `npm test` | 381 passing |
| `npm run verify:pdf` | twelve variants 11/11; `PDF_AUDIT.md` identical to `main` |
| `npm run audit:ats` | Recoverability 80/80; `ATS_AUDIT.md` identical to `main` |

## Reviews

- **Adversarial review (Codex): ran, no defects.** `codex exec` in a read-only sandbox over the branch's commits
  against `main` returned `NO DEFECTS`.
- **Product review: not needed.** An audit script and its rule; nothing the CV says or how it renders.

## Self-review

- `scripts/lib/pdf-variant.mjs:17` — a name that does not end in a paper and a colour mode throws, and `audit-pdfs`
  stops on it rather than scoring the file as A4. Every name the exporters write matches; a stray PDF dropped into the
  generator's output directory now stops the audit with an exception instead of passing as A4. No finding, but the
  exit code is 1, not the 2 an audit that could not check should give.
- The ticket's better option, taking the paper and the kind from what the generator records about each file, would
  remove the name parsing altogether. It needs the generator to record them, a larger change than this defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

