### PR TITLE
Report how much room each PDF variant has left

### DIFF
--- a/docs/PDF_AUDIT.md
+++ b/docs/PDF_AUDIT.md
@@ -2,19 +2,23 @@
 
 Generated variants: 12
 
-| File | Pages | Score |
-|---|---:|---:|
-| giovanni-trovato-general-en-nerd-a4-color.pdf | 2 | 12/12 |
-| giovanni-trovato-general-en-nerd-a4-monochrome.pdf | 2 | 12/12 |
-| giovanni-trovato-general-en-nerd-letter-color.pdf | 2 | 12/12 |
-| giovanni-trovato-general-en-nerd-letter-monochrome.pdf | 2 | 12/12 |
-| giovanni-trovato-general-en-spotlight-a4-color.pdf | 2 | 12/12 |
-| giovanni-trovato-general-en-spotlight-a4-monochrome.pdf | 2 | 12/12 |
-| giovanni-trovato-general-en-spotlight-letter-color.pdf | 2 | 12/12 |
-| giovanni-trovato-general-en-spotlight-letter-monochrome.pdf | 2 | 12/12 |
-| giovanni-trovato-general-en-technical-a4-color.pdf | 2 | 12/12 |
-| giovanni-trovato-general-en-technical-a4-monochrome.pdf | 2 | 12/12 |
-| giovanni-trovato-general-en-technical-letter-color.pdf | 2 | 12/12 |
-| giovanni-trovato-general-en-technical-letter-monochrome.pdf | 2 | 12/12 |
+Tightest: `giovanni-trovato-general-en-spotlight-letter-color.pdf` and `giovanni-trovato-general-en-spotlight-letter-monochrome.pdf`, with 11.3pt left below the last line of page 2 — 0.7 body lines of 15.75pt.
+
+| File | Pages | Room left | Score |
+|---|---:|---:|---:|
+| giovanni-trovato-general-en-nerd-a4-color.pdf | 2 | 196.7pt · 12.5 lines | 12/12 |
+| giovanni-trovato-general-en-nerd-a4-monochrome.pdf | 2 | 196.7pt · 12.5 lines | 12/12 |
+| giovanni-trovato-general-en-nerd-letter-color.pdf | 2 | 83.8pt · 5.3 lines | 12/12 |
+| giovanni-trovato-general-en-nerd-letter-monochrome.pdf | 2 | 83.8pt · 5.3 lines | 12/12 |
+| giovanni-trovato-general-en-spotlight-a4-color.pdf | 2 | 133.7pt · 8.5 lines | 12/12 |
+| giovanni-trovato-general-en-spotlight-a4-monochrome.pdf | 2 | 133.7pt · 8.5 lines | 12/12 |
+| giovanni-trovato-general-en-spotlight-letter-color.pdf | 2 | 11.3pt · 0.7 lines | 12/12 |
+| giovanni-trovato-general-en-spotlight-letter-monochrome.pdf | 2 | 11.3pt · 0.7 lines | 12/12 |
+| giovanni-trovato-general-en-technical-a4-color.pdf | 2 | 183.4pt · 11.6 lines | 12/12 |
+| giovanni-trovato-general-en-technical-a4-monochrome.pdf | 2 | 183.4pt · 11.6 lines | 12/12 |
+| giovanni-trovato-general-en-technical-letter-color.pdf | 2 | 86.3pt · 5.5 lines | 12/12 |
+| giovanni-trovato-general-en-technical-letter-monochrome.pdf | 2 | 86.3pt · 5.5 lines | 12/12 |
+
+Room left: the space between the lowest line on the last page and its bottom margin, in points and in body lines — the pitch of the type most of that page is set in. A copy change that adds more body lines than a variant has left makes it a page longer: judge an edit against the tightest variant before building, then build and audit.
 
 Checks: exact format, maximum two pages, required ATS text, reading order, no raster images, clean page starts, measured grayscale output, canonical compound spelling, block integrity in extraction, every skill category still attached to its own list, every web address recoverable from the text layer, and every certification on one line of its own, in the order the profile writes them.

--- a/scripts/audit-pdfs.mjs
+++ b/scripts/audit-pdfs.mjs
@@ -7,6 +7,9 @@ import { readableAddress } from '../domain/ReadableUrl.js';
 import { CoverLetter } from '../domain/CoverLetter.js';
 import { certificationProblems } from './lib/certification-lines.mjs';
 import { pdfVariant } from './lib/pdf-variant.mjs';
+import { pages as bboxPages, roomLeft } from './lib/room-left.mjs';
+import { PdfExporter } from '../core/PdfExporter.js';
+import { LetterExporter } from '../core/LetterExporter.js';
 
 const projectRoot = new URL('../', import.meta.url);
 // The expectations come from the CV under test, not from the published one. Auditing a
@@ -157,6 +160,18 @@ function highlightsIntact(collapsed) {
 const isCoverLetter = (filename) => pdfVariant(filename).coverLetter;
 const letter = profile.letter ? new CoverLetter(profile.letter) : null;
 
+// The bottom margin and line height each document was laid out with, from the composer that laid it
+// out: the room left is measured against the page the generator used, not against a copy of its numbers.
+const untranslated = { t: (key) => key };
+const laidOutWith = (definition) => ({
+  bottomMargin: definition.pageMargins[3],
+  lineHeight: definition.defaultStyle.lineHeight
+});
+const cvSettings = laidOutWith(new PdfExporter(null, untranslated).buildDocument(profile, {}));
+const letterSettings = letter
+  ? laidOutWith(new LetterExporter(null, untranslated).buildDocument(profile, {}))
+  : null;
+
 for (const filename of pdfFiles) {
   const path = new URL(filename, qaUrl).pathname;
   const info = execFileSync('pdfinfo', [path], { encoding: 'utf8' });
@@ -167,6 +182,22 @@ for (const filename of pdfFiles) {
   const expectedLetter = pdfVariant(filename).paper === 'letter';
   const sizeOk = expectedLetter ? /612 x 792 pts/.test(info) : /595\.28 x 841\.89 pts/.test(info);
   const pages = Number(info.match(/Pages:\s+(\d+)/)?.[1]);
+  // How much of the last page is left: whether a copy change fits, known before anyone builds it (#49).
+  const [lastPage] =
+    pages > 0
+      ? bboxPages(
+          execFileSync(
+            'pdftotext',
+            ['-bbox-layout', '-f', `${pages}`, '-l', `${pages}`, path, '-'],
+            {
+              encoding: 'utf8'
+            }
+          )
+        )
+      : [];
+  const room = lastPage?.lines.length
+    ? roomLeft(lastPage, isCoverLetter(filename) ? letterSettings : cvSettings)
+    : null;
   const pageTwo =
     pages > 1
       ? execFileSync('pdftotext', ['-f', '2', '-l', '2', path, '-'], { encoding: 'utf8' })
@@ -239,6 +270,7 @@ for (const filename of pdfFiles) {
   rows.push({
     filename,
     pages,
+    room,
     score: `${passed}/${Object.keys(checks).length}`,
     checks,
     ...(certifications.length ? { certifications } : {})
@@ -246,14 +278,29 @@ for (const filename of pdfFiles) {
 }
 
 const failures = rows.filter((row) => Object.values(row.checks).some((value) => !value));
+const roomText = (room) =>
+  room ? `${room.points.toFixed(1)}pt · ${room.lines.toFixed(1)} lines` : '—';
+const measured = rows.filter((row) => row.room);
+const least = Math.min(...measured.map((row) => row.room.points)).toFixed(1);
+const tightest = measured.filter((row) => row.room.points.toFixed(1) === least);
 const report = [
   '# PDF quality matrix',
   '',
   `Generated variants: ${rows.length}`,
   '',
-  '| File | Pages | Score |',
-  '|---|---:|---:|',
-  ...rows.map((row) => `| ${row.filename} | ${row.pages} | ${row.score} |`),
+  ...(tightest.length
+    ? [
+        `Tightest: ${tightest.map((row) => `\`${row.filename}\``).join(' and ')}, with ` +
+          `${least}pt left below the last line of page ${tightest[0].pages} — ` +
+          `${tightest[0].room.lines.toFixed(1)} body lines of ${tightest[0].room.bodyPitch.toFixed(2)}pt.`,
+        ''
+      ]
+    : []),
+  '| File | Pages | Room left | Score |',
+  '|---|---:|---:|---:|',
+  ...rows.map((row) => `| ${row.filename} | ${row.pages} | ${roomText(row.room)} | ${row.score} |`),
+  '',
+  'Room left: the space between the lowest line on the last page and its bottom margin, in points and in body lines — the pitch of the type most of that page is set in. A copy change that adds more body lines than a variant has left makes it a page longer: judge an edit against the tightest variant before building, then build and audit.',
   '',
   'Checks: exact format, maximum two pages, required ATS text, reading order, no raster images, clean page starts, measured grayscale output, canonical compound spelling, block integrity in extraction, every skill category still attached to its own list, every web address recoverable from the text layer, and every certification on one line of its own, in the order the profile writes them.'
 ].join('\n');

--- a/scripts/lib/room-left.mjs
+++ b/scripts/lib/room-left.mjs
@@ -1,0 +1,60 @@
+/**
+ * How much room a page has left below its last line, read from `pdftotext -bbox-layout` (#49).
+ *
+ * Whether a copy change fits used to be found out after the fact, by building and counting pages: #43
+ * took seven builds to learn that one description line pushed spotlight on LETTER to a third page.
+ *
+ * pdfmake sets each line in a box as tall as the font's height times the line height, and draws the
+ * glyphs at the top of that box. Measured on Inter at 9.3pt and a line height of 1.4: glyphs 11.253pt
+ * tall, one line every 15.754pt, the first line's top exactly on the 40pt margin. So a line ends at its
+ * top plus its glyph height times the line height, and a page is full when less than one body line fits
+ * between there and the bottom margin. Measured from the glyphs' bottom instead, a full page shows the
+ * 4.5pt of leading under its last line as room nobody can use.
+ */
+
+const attribute = (tag, name) => Number(new RegExp(`\\b${name}="([\\d.]+)"`).exec(tag)?.[1]);
+
+/**
+ * Every page of an extract, with the vertical extent of each line on it.
+ * @param {string} extract - What `pdftotext -bbox-layout` wrote
+ * @returns {{ width: number, height: number, lines: { top: number, bottom: number }[] }[]} The pages
+ */
+export function pages(extract) {
+  return extract
+    .split(/<page\b/)
+    .slice(1)
+    .map((page) => ({
+      width: attribute(page, 'width'),
+      height: attribute(page, 'height'),
+      lines: [...page.matchAll(/<line\b[^>]*>/g)].map(([tag]) => ({
+        top: attribute(tag, 'yMin'),
+        bottom: attribute(tag, 'yMax')
+      }))
+    }));
+}
+
+/**
+ * The room between a page's lowest line and its bottom margin, in points and in body lines.
+ *
+ * A body line is the pitch of the type most of the page is set in: the commonest glyph height, times
+ * the line height. Titles, labels and dates come in other sizes, but the lines a copy change adds to a
+ * CV are body lines.
+ * @param {{ height: number, lines: { top: number, bottom: number }[] }} page - One page, from `pages`
+ * @param {{ bottomMargin: number, lineHeight: number }} settings - What the document was laid out with
+ * @returns {{ points: number, lines: number, bodyPitch: number }} The room left
+ */
+export function roomLeft({ height, lines }, { bottomMargin, lineHeight }) {
+  if (!lines.length) throw new Error('A page with no line has no last line to measure from.');
+
+  const glyphHeights = new Map();
+  for (const { top, bottom } of lines) {
+    const glyph = (bottom - top).toFixed(2);
+    glyphHeights.set(glyph, (glyphHeights.get(glyph) || 0) + 1);
+  }
+  const [[commonest]] = [...glyphHeights].sort((a, b) => b[1] - a[1]);
+  const bodyPitch = Number(commonest) * lineHeight;
+
+  const lowest = Math.max(...lines.map(({ top, bottom }) => top + (bottom - top) * lineHeight));
+  const points = height - bottomMargin - lowest;
+  return { points, lines: points / bodyPitch, bodyPitch };
+}

--- a/tests/RoomLeft.test.js
+++ b/tests/RoomLeft.test.js
@@ -1,0 +1,51 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync } from 'node:fs';
+import { pages, roomLeft } from '../scripts/lib/room-left.mjs';
+
+// `pdftotext -bbox-layout` of a document pdfmake built from 46 one-line paragraphs on LETTER, set the
+// way the CV sets its body: Inter at 9.3pt, a line height of 1.4, 40pt top and bottom margins. Page one
+// holds 45 lines — pdfmake had no room for the 46th and started page two with it — so page one is a
+// page known to be full, and page two holds a single line (#49).
+const extract = readFileSync(
+  new URL('./fixtures/room-left/forty-six-lines.txt', import.meta.url),
+  'utf8'
+);
+const settings = { bottomMargin: 40, lineHeight: 1.4 };
+
+describe('the room left on a page', () => {
+  test('reads every page of the extract, and the lines on each', () => {
+    const [full, last] = pages(extract);
+
+    expect(pages(extract)).toHaveLength(2);
+    expect([full.lines.length, last.lines.length]).toEqual([45, 1]);
+    expect(full.height).toBe(792);
+  });
+
+  test('on a page known to be full, is less than one body line', () => {
+    const { points, lines } = roomLeft(pages(extract)[0], settings);
+
+    expect(points).toBeGreaterThanOrEqual(0);
+    expect(lines).toBeLessThan(1);
+  });
+
+  test('below a single line, is every line the full page held but one', () => {
+    const { lines } = roomLeft(pages(extract)[1], settings);
+
+    expect(Math.floor(lines)).toBe(44);
+  });
+
+  // pdfmake draws the glyphs at the top of the line box and leaves the leading below them. Measured
+  // from the glyphs' bottom, the full page would show 7.6pt free: half a line nobody can use.
+  test('ends a line where its box ends, not where its glyphs do', () => {
+    const { points, bodyPitch } = roomLeft(pages(extract)[0], settings);
+
+    expect(bodyPitch).toBeCloseTo(15.75, 1);
+    expect(points).toBeCloseTo(3.1, 1);
+  });
+
+  test('a page with no text has nothing to measure from', () => {
+    expect(() => roomLeft({ width: 612, height: 792, lines: [] }, settings)).toThrow(/no line/);
+  });
+});

--- a/tests/fixtures/room-left/forty-six-lines.txt
+++ b/tests/fixtures/room-left/forty-six-lines.txt
@@ -1,0 +1,342 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd"><html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+<title>Room left fixture</title>
+<meta name="Creator" content="pdfmake"/>
+<meta name="Producer" content="pdfmake"/>
+<meta name="CreationDate" content="1970-01-01T00:00:00Z"/>
+</head>
+<body>
+<doc>
+  <page width="612.000000" height="792.000000">
+    <flow>
+      <block xMin="46.000000" yMin="40.000000" xMax="93.063086" yMax="51.252637">
+        <line xMin="46.000000" yMin="40.000000" xMax="93.063086" yMax="51.252637">
+          <word xMin="46.000000" yMin="40.000000" xMax="68.627881" yMax="51.252637">Body</word>
+          <word xMin="71.243506" yMin="40.000000" xMax="86.664795" yMax="51.252637">line</word>
+          <word xMin="89.280420" yMin="40.000000" xMax="93.063086" yMax="51.252637">1</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="55.753691" xMax="94.952149" yMax="67.006328">
+        <line xMin="46.000000" yMin="55.753691" xMax="94.952149" yMax="67.006328">
+          <word xMin="46.000000" yMin="55.753691" xMax="68.627881" yMax="67.006328">Body</word>
+          <word xMin="71.243506" yMin="55.753691" xMax="86.664795" yMax="67.006328">line</word>
+          <word xMin="89.280420" yMin="55.753691" xMax="94.952149" yMax="67.006328">2</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="71.507383" xMax="95.024805" yMax="82.760020">
+        <line xMin="46.000000" yMin="71.507383" xMax="95.024805" yMax="82.760020">
+          <word xMin="46.000000" yMin="71.507383" xMax="68.627881" yMax="82.760020">Body</word>
+          <word xMin="71.243506" yMin="71.507383" xMax="86.664795" yMax="82.760020">line</word>
+          <word xMin="89.280420" yMin="71.507383" xMax="95.024805" yMax="82.760020">3</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="87.261074" xMax="95.288184" yMax="98.513711">
+        <line xMin="46.000000" yMin="87.261074" xMax="95.288184" yMax="98.513711">
+          <word xMin="46.000000" yMin="87.261074" xMax="68.627881" yMax="98.513711">Body</word>
+          <word xMin="71.243506" yMin="87.261074" xMax="86.664795" yMax="98.513711">line</word>
+          <word xMin="89.280420" yMin="87.261074" xMax="95.288184" yMax="98.513711">4</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="103.014766" xMax="94.797754" yMax="114.267403">
+        <line xMin="46.000000" yMin="103.014766" xMax="94.797754" yMax="114.267403">
+          <word xMin="46.000000" yMin="103.014766" xMax="68.627881" yMax="114.267403">Body</word>
+          <word xMin="71.243506" yMin="103.014766" xMax="86.664795" yMax="114.267403">line</word>
+          <word xMin="89.280420" yMin="103.014766" xMax="94.797754" yMax="114.267403">5</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="118.768457" xMax="95.047510" yMax="130.021094">
+        <line xMin="46.000000" yMin="118.768457" xMax="95.047510" yMax="130.021094">
+          <word xMin="46.000000" yMin="118.768457" xMax="68.627881" yMax="130.021094">Body</word>
+          <word xMin="71.243506" yMin="118.768457" xMax="86.664795" yMax="130.021094">line</word>
+          <word xMin="89.280420" yMin="118.768457" xMax="95.047510" yMax="130.021094">6</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="134.522148" xMax="94.543457" yMax="145.774785">
+        <line xMin="46.000000" yMin="134.522148" xMax="94.543457" yMax="145.774785">
+          <word xMin="46.000000" yMin="134.522148" xMax="68.627881" yMax="145.774785">Body</word>
+          <word xMin="71.243506" yMin="134.522148" xMax="86.664795" yMax="145.774785">line</word>
+          <word xMin="89.280420" yMin="134.522148" xMax="94.543457" yMax="145.774785">7</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="150.275840" xMax="95.033887" yMax="161.528477">
+        <line xMin="46.000000" yMin="150.275840" xMax="95.033887" yMax="161.528477">
+          <word xMin="46.000000" yMin="150.275840" xMax="68.627881" yMax="161.528477">Body</word>
+          <word xMin="71.243506" yMin="150.275840" xMax="86.664795" yMax="161.528477">line</word>
+          <word xMin="89.280420" yMin="150.275840" xMax="95.033887" yMax="161.528477">8</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="166.029531" xMax="95.047510" yMax="177.282168">
+        <line xMin="46.000000" yMin="166.029531" xMax="95.047510" yMax="177.282168">
+          <word xMin="46.000000" yMin="166.029531" xMax="68.627881" yMax="177.282168">Body</word>
+          <word xMin="71.243506" yMin="166.029531" xMax="86.664795" yMax="177.282168">line</word>
+          <word xMin="89.280420" yMin="166.029531" xMax="95.047510" yMax="177.282168">9</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="181.783223" xMax="98.930078" yMax="193.035860">
+        <line xMin="46.000000" yMin="181.783223" xMax="98.930078" yMax="193.035860">
+          <word xMin="46.000000" yMin="181.783223" xMax="68.627881" yMax="193.035860">Body</word>
+          <word xMin="71.243506" yMin="181.783223" xMax="86.664795" yMax="193.035860">line</word>
+          <word xMin="89.280420" yMin="181.783223" xMax="98.930078" yMax="193.035860">10</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="197.536914" xMax="96.845752" yMax="208.789551">
+        <line xMin="46.000000" yMin="197.536914" xMax="96.845752" yMax="208.789551">
+          <word xMin="46.000000" yMin="197.536914" xMax="68.627881" yMax="208.789551">Body</word>
+          <word xMin="71.243506" yMin="197.536914" xMax="86.664795" yMax="208.789551">line</word>
+          <word xMin="89.280420" yMin="197.536914" xMax="96.845752" yMax="208.789551">11</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="213.290605" xMax="98.734815" yMax="224.543242">
+        <line xMin="46.000000" yMin="213.290605" xMax="98.734815" yMax="224.543242">
+          <word xMin="46.000000" yMin="213.290605" xMax="68.627881" yMax="224.543242">Body</word>
+          <word xMin="71.243506" yMin="213.290605" xMax="86.664795" yMax="224.543242">line</word>
+          <word xMin="89.280420" yMin="213.290605" xMax="98.734815" yMax="224.543242">12</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="229.044297" xMax="98.807471" yMax="240.296934">
+        <line xMin="46.000000" yMin="229.044297" xMax="98.807471" yMax="240.296934">
+          <word xMin="46.000000" yMin="229.044297" xMax="68.627881" yMax="240.296934">Body</word>
+          <word xMin="71.243506" yMin="229.044297" xMax="86.664795" yMax="240.296934">line</word>
+          <word xMin="89.280420" yMin="229.044297" xMax="98.807471" yMax="240.296934">13</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="244.797988" xMax="99.070850" yMax="256.050625">
+        <line xMin="46.000000" yMin="244.797988" xMax="99.070850" yMax="256.050625">
+          <word xMin="46.000000" yMin="244.797988" xMax="68.627881" yMax="256.050625">Body</word>
+          <word xMin="71.243506" yMin="244.797988" xMax="86.664795" yMax="256.050625">line</word>
+          <word xMin="89.280420" yMin="244.797988" xMax="99.070850" yMax="256.050625">14</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="260.551680" xMax="98.580420" yMax="271.804317">
+        <line xMin="46.000000" yMin="260.551680" xMax="98.580420" yMax="271.804317">
+          <word xMin="46.000000" yMin="260.551680" xMax="68.627881" yMax="271.804317">Body</word>
+          <word xMin="71.243506" yMin="260.551680" xMax="86.664795" yMax="271.804317">line</word>
+          <word xMin="89.280420" yMin="260.551680" xMax="98.580420" yMax="271.804317">15</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="276.305371" xMax="98.830176" yMax="287.558008">
+        <line xMin="46.000000" yMin="276.305371" xMax="98.830176" yMax="287.558008">
+          <word xMin="46.000000" yMin="276.305371" xMax="68.627881" yMax="287.558008">Body</word>
+          <word xMin="71.243506" yMin="276.305371" xMax="86.664795" yMax="287.558008">line</word>
+          <word xMin="89.280420" yMin="276.305371" xMax="98.830176" yMax="287.558008">16</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="292.059062" xMax="98.326123" yMax="303.311699">
+        <line xMin="46.000000" yMin="292.059062" xMax="98.326123" yMax="303.311699">
+          <word xMin="46.000000" yMin="292.059062" xMax="68.627881" yMax="303.311699">Body</word>
+          <word xMin="71.243506" yMin="292.059062" xMax="86.664795" yMax="303.311699">line</word>
+          <word xMin="89.280420" yMin="292.059062" xMax="98.326123" yMax="303.311699">17</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="307.812754" xMax="98.816553" yMax="319.065391">
+        <line xMin="46.000000" yMin="307.812754" xMax="98.816553" yMax="319.065391">
+          <word xMin="46.000000" yMin="307.812754" xMax="68.627881" yMax="319.065391">Body</word>
+          <word xMin="71.243506" yMin="307.812754" xMax="86.664795" yMax="319.065391">line</word>
+          <word xMin="89.280420" yMin="307.812754" xMax="98.816553" yMax="319.065391">18</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="323.566445" xMax="98.830176" yMax="334.819082">
+        <line xMin="46.000000" yMin="323.566445" xMax="98.830176" yMax="334.819082">
+          <word xMin="46.000000" yMin="323.566445" xMax="68.627881" yMax="334.819082">Body</word>
+          <word xMin="71.243506" yMin="323.566445" xMax="86.664795" yMax="334.819082">line</word>
+          <word xMin="89.280420" yMin="323.566445" xMax="98.830176" yMax="334.819082">19</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="339.320137" xMax="100.819141" yMax="350.572774">
+        <line xMin="46.000000" yMin="339.320137" xMax="100.819141" yMax="350.572774">
+          <word xMin="46.000000" yMin="339.320137" xMax="68.627881" yMax="350.572774">Body</word>
+          <word xMin="71.243506" yMin="339.320137" xMax="86.664795" yMax="350.572774">line</word>
+          <word xMin="89.280420" yMin="339.320137" xMax="100.819141" yMax="350.572774">20</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="355.073828" xMax="98.734815" yMax="366.326465">
+        <line xMin="46.000000" yMin="355.073828" xMax="98.734815" yMax="366.326465">
+          <word xMin="46.000000" yMin="355.073828" xMax="68.627881" yMax="366.326465">Body</word>
+          <word xMin="71.243506" yMin="355.073828" xMax="86.664795" yMax="366.326465">line</word>
+          <word xMin="89.280420" yMin="355.073828" xMax="98.734815" yMax="366.326465">21</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="370.827520" xMax="100.623877" yMax="382.080157">
+        <line xMin="46.000000" yMin="370.827520" xMax="100.623877" yMax="382.080157">
+          <word xMin="46.000000" yMin="370.827520" xMax="68.627881" yMax="382.080157">Body</word>
+          <word xMin="71.243506" yMin="370.827520" xMax="86.664795" yMax="382.080157">line</word>
+          <word xMin="89.280420" yMin="370.827520" xMax="100.623877" yMax="382.080157">22</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="386.581211" xMax="100.696533" yMax="397.833848">
+        <line xMin="46.000000" yMin="386.581211" xMax="100.696533" yMax="397.833848">
+          <word xMin="46.000000" yMin="386.581211" xMax="68.627881" yMax="397.833848">Body</word>
+          <word xMin="71.243506" yMin="386.581211" xMax="86.664795" yMax="397.833848">line</word>
+          <word xMin="89.280420" yMin="386.581211" xMax="100.696533" yMax="397.833848">23</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="402.334902" xMax="100.669287" yMax="413.587539">
+        <line xMin="46.000000" yMin="402.334902" xMax="100.669287" yMax="413.587539">
+          <word xMin="46.000000" yMin="402.334902" xMax="68.627881" yMax="413.587539">Body</word>
+          <word xMin="71.243506" yMin="402.334902" xMax="86.664795" yMax="413.587539">line</word>
+          <word xMin="89.280420" yMin="402.334902" xMax="100.669287" yMax="413.587539">24</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="418.088594" xMax="100.469482" yMax="429.341231">
+        <line xMin="46.000000" yMin="418.088594" xMax="100.469482" yMax="429.341231">
+          <word xMin="46.000000" yMin="418.088594" xMax="68.627881" yMax="429.341231">Body</word>
+          <word xMin="71.243506" yMin="418.088594" xMax="86.664795" yMax="429.341231">line</word>
+          <word xMin="89.280420" yMin="418.088594" xMax="100.469482" yMax="429.341231">25</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="433.842285" xMax="100.719238" yMax="445.094922">
+        <line xMin="46.000000" yMin="433.842285" xMax="100.719238" yMax="445.094922">
+          <word xMin="46.000000" yMin="433.842285" xMax="68.627881" yMax="445.094922">Body</word>
+          <word xMin="71.243506" yMin="433.842285" xMax="86.664795" yMax="445.094922">line</word>
+          <word xMin="89.280420" yMin="433.842285" xMax="100.719238" yMax="445.094922">26</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="449.595977" xMax="100.215186" yMax="460.848614">
+        <line xMin="46.000000" yMin="449.595977" xMax="100.215186" yMax="460.848614">
+          <word xMin="46.000000" yMin="449.595977" xMax="68.627881" yMax="460.848614">Body</word>
+          <word xMin="71.243506" yMin="449.595977" xMax="86.664795" yMax="460.848614">line</word>
+          <word xMin="89.280420" yMin="449.595977" xMax="100.215186" yMax="460.848614">27</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="465.349668" xMax="100.705615" yMax="476.602305">
+        <line xMin="46.000000" yMin="465.349668" xMax="100.705615" yMax="476.602305">
+          <word xMin="46.000000" yMin="465.349668" xMax="68.627881" yMax="476.602305">Body</word>
+          <word xMin="71.243506" yMin="465.349668" xMax="86.664795" yMax="476.602305">line</word>
+          <word xMin="89.280420" yMin="465.349668" xMax="100.705615" yMax="476.602305">28</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="481.103359" xMax="100.719238" yMax="492.355996">
+        <line xMin="46.000000" yMin="481.103359" xMax="100.719238" yMax="492.355996">
+          <word xMin="46.000000" yMin="481.103359" xMax="68.627881" yMax="492.355996">Body</word>
+          <word xMin="71.243506" yMin="481.103359" xMax="86.664795" yMax="492.355996">line</word>
+          <word xMin="89.280420" yMin="481.103359" xMax="100.719238" yMax="492.355996">29</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="496.857051" xMax="100.891797" yMax="508.109688">
+        <line xMin="46.000000" yMin="496.857051" xMax="100.891797" yMax="508.109688">
+          <word xMin="46.000000" yMin="496.857051" xMax="68.627881" yMax="508.109688">Body</word>
+          <word xMin="71.243506" yMin="496.857051" xMax="86.664795" yMax="508.109688">line</word>
+          <word xMin="89.280420" yMin="496.857051" xMax="100.891797" yMax="508.109688">30</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="512.610742" xMax="98.807471" yMax="523.863379">
+        <line xMin="46.000000" yMin="512.610742" xMax="98.807471" yMax="523.863379">
+          <word xMin="46.000000" yMin="512.610742" xMax="68.627881" yMax="523.863379">Body</word>
+          <word xMin="71.243506" yMin="512.610742" xMax="86.664795" yMax="523.863379">line</word>
+          <word xMin="89.280420" yMin="512.610742" xMax="98.807471" yMax="523.863379">31</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="528.364434" xMax="100.696533" yMax="539.617071">
+        <line xMin="46.000000" yMin="528.364434" xMax="100.696533" yMax="539.617071">
+          <word xMin="46.000000" yMin="528.364434" xMax="68.627881" yMax="539.617071">Body</word>
+          <word xMin="71.243506" yMin="528.364434" xMax="86.664795" yMax="539.617071">line</word>
+          <word xMin="89.280420" yMin="528.364434" xMax="100.696533" yMax="539.617071">32</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="544.118125" xMax="100.769190" yMax="555.370762">
+        <line xMin="46.000000" yMin="544.118125" xMax="100.769190" yMax="555.370762">
+          <word xMin="46.000000" yMin="544.118125" xMax="68.627881" yMax="555.370762">Body</word>
+          <word xMin="71.243506" yMin="544.118125" xMax="86.664795" yMax="555.370762">line</word>
+          <word xMin="89.280420" yMin="544.118125" xMax="100.769190" yMax="555.370762">33</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="559.871816" xMax="101.032568" yMax="571.124453">
+        <line xMin="46.000000" yMin="559.871816" xMax="101.032568" yMax="571.124453">
+          <word xMin="46.000000" yMin="559.871816" xMax="68.627881" yMax="571.124453">Body</word>
+          <word xMin="71.243506" yMin="559.871816" xMax="86.664795" yMax="571.124453">line</word>
+          <word xMin="89.280420" yMin="559.871816" xMax="101.032568" yMax="571.124453">34</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="575.625508" xMax="100.542139" yMax="586.878145">
+        <line xMin="46.000000" yMin="575.625508" xMax="100.542139" yMax="586.878145">
+          <word xMin="46.000000" yMin="575.625508" xMax="68.627881" yMax="586.878145">Body</word>
+          <word xMin="71.243506" yMin="575.625508" xMax="86.664795" yMax="586.878145">line</word>
+          <word xMin="89.280420" yMin="575.625508" xMax="100.542139" yMax="586.878145">35</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="591.379199" xMax="100.791895" yMax="602.631836">
+        <line xMin="46.000000" yMin="591.379199" xMax="100.791895" yMax="602.631836">
+          <word xMin="46.000000" yMin="591.379199" xMax="68.627881" yMax="602.631836">Body</word>
+          <word xMin="71.243506" yMin="591.379199" xMax="86.664795" yMax="602.631836">line</word>
+          <word xMin="89.280420" yMin="591.379199" xMax="100.791895" yMax="602.631836">36</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="607.132891" xMax="100.287842" yMax="618.385528">
+        <line xMin="46.000000" yMin="607.132891" xMax="100.287842" yMax="618.385528">
+          <word xMin="46.000000" yMin="607.132891" xMax="68.627881" yMax="618.385528">Body</word>
+          <word xMin="71.243506" yMin="607.132891" xMax="86.664795" yMax="618.385528">line</word>
+          <word xMin="89.280420" yMin="607.132891" xMax="100.287842" yMax="618.385528">37</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="622.886582" xMax="100.778272" yMax="634.139219">
+        <line xMin="46.000000" yMin="622.886582" xMax="100.778272" yMax="634.139219">
+          <word xMin="46.000000" yMin="622.886582" xMax="68.627881" yMax="634.139219">Body</word>
+          <word xMin="71.243506" yMin="622.886582" xMax="86.664795" yMax="634.139219">line</word>
+          <word xMin="89.280420" yMin="622.886582" xMax="100.778272" yMax="634.139219">38</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="638.640273" xMax="100.791895" yMax="649.892910">
+        <line xMin="46.000000" yMin="638.640273" xMax="100.791895" yMax="649.892910">
+          <word xMin="46.000000" yMin="638.640273" xMax="68.627881" yMax="649.892910">Body</word>
+          <word xMin="71.243506" yMin="638.640273" xMax="86.664795" yMax="649.892910">line</word>
+          <word xMin="89.280420" yMin="638.640273" xMax="100.791895" yMax="649.892910">39</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="654.393965" xMax="101.155176" yMax="665.646602">
+        <line xMin="46.000000" yMin="654.393965" xMax="101.155176" yMax="665.646602">
+          <word xMin="46.000000" yMin="654.393965" xMax="68.627881" yMax="665.646602">Body</word>
+          <word xMin="71.243506" yMin="654.393965" xMax="86.664795" yMax="665.646602">line</word>
+          <word xMin="89.280420" yMin="654.393965" xMax="101.155176" yMax="665.646602">40</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="670.147656" xMax="98.707568" yMax="681.400293">
+        <line xMin="46.000000" yMin="670.147656" xMax="98.707568" yMax="681.400293">
+          <word xMin="46.000000" yMin="670.147656" xMax="68.627881" yMax="681.400293">Body</word>
+          <word xMin="71.243506" yMin="670.147656" xMax="86.664795" yMax="681.400293">line</word>
+          <word xMin="89.280420" yMin="670.147656" xMax="98.707568" yMax="681.400293">41</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="685.901348" xMax="100.959912" yMax="697.153985">
+        <line xMin="46.000000" yMin="685.901348" xMax="100.959912" yMax="697.153985">
+          <word xMin="46.000000" yMin="685.901348" xMax="68.627881" yMax="697.153985">Body</word>
+          <word xMin="71.243506" yMin="685.901348" xMax="86.664795" yMax="697.153985">line</word>
+          <word xMin="89.280420" yMin="685.901348" xMax="100.959912" yMax="697.153985">42</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="701.655039" xMax="101.032568" yMax="712.907676">
+        <line xMin="46.000000" yMin="701.655039" xMax="101.032568" yMax="712.907676">
+          <word xMin="46.000000" yMin="701.655039" xMax="68.627881" yMax="712.907676">Body</word>
+          <word xMin="71.243506" yMin="701.655039" xMax="86.664795" yMax="712.907676">line</word>
+          <word xMin="89.280420" yMin="701.655039" xMax="101.032568" yMax="712.907676">43</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="717.408730" xMax="101.295947" yMax="728.661367">
+        <line xMin="46.000000" yMin="717.408730" xMax="101.295947" yMax="728.661367">
+          <word xMin="46.000000" yMin="717.408730" xMax="68.627881" yMax="728.661367">Body</word>
+          <word xMin="71.243506" yMin="717.408730" xMax="86.664795" yMax="728.661367">line</word>
+          <word xMin="89.280420" yMin="717.408730" xMax="101.295947" yMax="728.661367">44</word>
+        </line>
+      </block>
+      <block xMin="46.000000" yMin="733.162422" xMax="100.805518" yMax="744.415059">
+        <line xMin="46.000000" yMin="733.162422" xMax="100.805518" yMax="744.415059">
+          <word xMin="46.000000" yMin="733.162422" xMax="68.627881" yMax="744.415059">Body</word>
+          <word xMin="71.243506" yMin="733.162422" xMax="86.664795" yMax="744.415059">line</word>
+          <word xMin="89.280420" yMin="733.162422" xMax="100.805518" yMax="744.415059">45</word>
+        </line>
+      </block>
+    </flow>
+  </page>
+  <page width="612.000000" height="792.000000">
+    <flow>
+      <block xMin="46.000000" yMin="40.000000" xMax="101.055274" yMax="51.252637">
+        <line xMin="46.000000" yMin="40.000000" xMax="101.055274" yMax="51.252637">
+          <word xMin="46.000000" yMin="40.000000" xMax="68.627881" yMax="51.252637">Body</word>
+          <word xMin="71.243506" yMin="40.000000" xMax="86.664795" yMax="51.252637">line</word>
+          <word xMin="89.280420" yMin="40.000000" xMax="101.055274" yMax="51.252637">46</word>
+        </line>
+      </block>
+    </flow>
+  </page>
+</doc>
+</body>
+</html>


### PR DESCRIPTION
> **The adversarial review has not run yet.** Codex is at its usage limit until 15 September, 09:56. The review is queued for then, and this pull request stays a draft until its findings are answered.

## What

`npm run audit:pdf` now reports the room left on the last page of every variant, in points and in body lines, and names the tightest variant at the top of `docs/PDF_AUDIT.md`. A copy change can be judged against that variant before anyone builds.

Refs #49

## How it measures

`pdftotext -bbox-layout` gives the top and bottom of every line on the last page. pdfmake draws a line's glyphs at the top of its line box and leaves the leading below them. So a line ends at its top plus its glyph height times the line height. Measured on Inter at 9.3pt, the glyphs are 11.253pt tall, a line comes every 15.754pt, and the first line's top sits exactly on the 40pt margin.

- **Room left:** the page height, minus the bottom margin, minus the bottom of the lowest line box.
- **Body line:** the commonest glyph height on the page times the line height.
- **Inputs:** the margin and the line height come from the composer that laid the document out, not from a copy of its numbers.

The product review on #47 measured from the glyphs' bottom, by hand. That reads the 4.5pt of leading under the last line as room, which is why every figure below is smaller than the ones in the ticket.

## What it says today

The tightest variant is spotlight on LETTER, in colour and in monochrome: **11.3pt, 0.7 of a body line**. One more body line anywhere in spotlight gives its LETTER variant a third page.

| Layout | A4 | LETTER |
|---|---:|---:|
| spotlight | 133.7pt · 8.5 lines | 11.3pt · 0.7 lines |
| technical | 183.4pt · 11.6 lines | 86.3pt · 5.5 lines |
| nerd | 196.7pt · 12.5 lines | 83.8pt · 5.3 lines |

The figure is reported and gates nothing, as the ticket asks.

## Proof

- **A page known to be full.** `tests/RoomLeft.test.js` reads the `pdftotext -bbox-layout` output of a document pdfmake built from 46 one-line paragraphs on LETTER, set in the CV's body settings. pdfmake fit 45 lines on page one and started page two with the 46th.
  - On page one the measurement leaves 3.1pt, which is 0.2 of a line.
  - On page two, below the single line, it leaves 44.2 lines: the 44 more lines the full page held.
- **The box model.** A separate test pins the difference between the two ways of measuring: from the glyphs' bottom, the same full page would show 7.6pt free.
- **Gates.** `npm test` passes, `npm run verify:pdf` scores 12/12 on all twelve variants, and the formatting check passes.

## Reviews

- **Adversarial (codex-cli):** not run yet; queued for the usage-limit reset on 15 September.
- **Product review:** skipped. The diff touches the audit script, a test, a fixture and the audit report, not what the CV says or how it renders.

## Self-review

- `scripts/audit-pdfs.mjs`: every CV variant is measured against the margin of the composer's default layout. This is correct today, because `adapters/PdfLayout.js:166` gives every layout and paper the same `[SIDE, 40, SIDE, 40]`. A layout that ever sets its own bottom margin would need its name read from the filename. Observation, no change.
- `scripts/lib/room-left.mjs`: a body line is the commonest glyph height on the last page. A page carrying more 9pt meta lines than 9.3pt body lines would count in lines of 15.25pt rather than 15.75pt, an error of about 3%. Observation, no change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
