### PR TITLE
Run the screen audit with the other gates

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -61,6 +61,13 @@ jobs:
         env:
           CHROME_PATH: /usr/bin/google-chrome
 
+      # audit-screen exits 2 and checks nothing when it finds no browser, as the print audit does, and
+      # any exit but 0 fails the step. JSDOM cannot see what a selection copies; this can (#62, #89).
+      - name: Audit what a reader copies off the screen
+        run: npm run audit:screen
+        env:
+          CHROME_PATH: /usr/bin/google-chrome
+
       - name: Collect the reports this run wrote
         if: always()
         run: |

--- a/scripts/audit-screen.mjs
+++ b/scripts/audit-screen.mjs
@@ -97,6 +97,11 @@ async function openBrowser(binary, dataDir) {
     ],
     { stdio: ['ignore', 'ignore', 'pipe'] }
   );
+  // Settles once the browser is gone, whether it stopped or never started.
+  const gone = new Promise((resolve) => {
+    child.once('exit', resolve);
+    child.once('error', resolve);
+  });
   const pending = new Map();
   const listeners = new Set();
   let socket;
@@ -106,9 +111,21 @@ async function openBrowser(binary, dataDir) {
     for (const { reject } of pending.values()) reject(new Error(reason));
     pending.clear();
   };
-  const close = () => {
+  // Resolves once the browser has exited. Killed outright, its renderers outlived it and went on writing
+  // into the profile directory the audit removes next: on the CI runner that removal failed with
+  // ENOTEMPTY on every run, after every check had passed, and the audit exited 1 with no report (#89).
+  // Asked to stop, Chrome closes its profile first; only a browser that does not stop is killed.
+  const close = async () => {
     socket?.close();
-    child.kill('SIGKILL');
+    child.kill('SIGTERM');
+    const stopped = await within(gone, 5000, 'the browser did not stop').then(
+      () => true,
+      () => false
+    );
+    if (!stopped) {
+      child.kill('SIGKILL');
+      await within(gone, 5000, 'the browser did not exit').catch(() => {});
+    }
   };
 
   try {
@@ -149,7 +166,7 @@ async function openBrowser(binary, dataDir) {
       'the DevTools socket did not open'
     );
   } catch (error) {
-    close();
+    await close();
     throw error;
   }
 
@@ -284,10 +301,13 @@ try {
   console.error(`audit-screen: ${error.message} — nothing was checked.`);
   process.exitCode = 2;
 } finally {
-  chrome?.close();
+  await chrome?.close();
   server.closeAllConnections?.();
   server.close();
-  await rm(dataDir, { recursive: true, force: true });
+  // What is left behind is a temporary directory, not a result: say so, and let the checks stand.
+  await rm(dataDir, { recursive: true, force: true, maxRetries: 5, retryDelay: 200 }).catch(
+    (error) => console.error(`audit-screen: left ${dataDir} behind — ${error.message}`)
+  );
 }
 if (process.exitCode === 2) process.exit(2);
 


### PR DESCRIPTION
> **The adversarial review has not run yet.** Codex is at its usage limit until 15 September, 09:56. The review is queued for then, and this pull request stays a draft until its findings are answered.

## What

`npm run audit:screen` (#62) merged after the gates workflow (#28) and was never one of its steps. A change that welded two words in what a reader copies, or wrote a pictograph into the page, passed CI. The audit now runs after the print audit, with the same `CHROME_PATH`.

Refs #89

## Two commits

1. **`ci: run the screen audit with the other gates`**: the step itself. The collect step already takes every `docs/*_AUDIT.md` newer than the start of the run, so `SCREEN_AUDIT.md` goes into the artifact exactly when the audit wrote it.
2. **`fix: let the browser exit before the screen audit removes its profile`**: the step's first run ([34708495984](https://github.com/PigLardLord/cv-giovanni/actions/runs/34708495984)) failed on a clean branch. **The defect is mine, from #62**; locally the browser happened to exit first.
   - **What went wrong.** The audit checked all six layouts, then crashed removing Chrome's profile directory. `close()` killed the browser with SIGKILL, its renderers went on writing, and the removal failed with `ENOTEMPTY`. The uncaught error exited 1 with no report written: the code for a finding, after every check had passed.
   - **The fix.** `close()` now sends SIGTERM and waits, and kills only a browser that does not stop. The removal retries, and a directory left behind is reported without discarding the checks.

## Proof on the real pipeline

| Run | What was pushed | Screen audit step | Every other step | Reports in the artifact |
|---|---|---|---|---|
| [34709490802](https://github.com/PigLardLord/cv-giovanni/actions/runs/34709490802) | this branch | **success**, 5/5 on all six | success | ATS, PDF, PRINT, **SCREEN** |
| [34709558953](https://github.com/PigLardLord/cv-giovanni/actions/runs/34709558953) | proof: the contact card's pin written back into the page, hidden from print by `print.css` | **failure**, exit 1: `nothingUnwritten` on spotlight and technical at both widths, `"📍 Bad Liebenstein, Thuringia, Germany"` | success: formatting, tests, and the PDF, ATS and print audits | ATS, PDF, PRINT, **SCREEN** |
| [34709612802](https://github.com/PigLardLord/cv-giovanni/actions/runs/34709612802) | proof: the audit pointed at a profile that does not exist | **failure**, exit 2: `cannot read profiles/general/xx.json — nothing was checked` | success | ATS, PDF, PRINT, **no SCREEN** |

Against the ticket's acceptance criteria:

- **A pictograph fails CI on the screen audit and on nothing else:** run 34709558953.
- **The artifact carries `SCREEN_AUDIT.md` when the audit ran, and not when it did not:** runs 34709490802 and 34709558953 against 34709612802.
- **An audit that could not run (exit 2) fails the job:** run 34709612802.

The throwaway branch `proof/89-screen-audit-red` has been deleted. The runs and their logs remain.

**Locally**, after the fix, `npm run audit:screen` ran three times in a row: exit 0 each time, 5/5 on all six, no temporary profile left behind. `npm test`: 511 passed.

## Reviews

- **Adversarial (codex-cli):** not run yet; queued for the usage-limit reset on 15 September.
- **Product review:** skipped. The diff touches the workflow and an audit script, not what the CV says or how it renders.

## Self-review

- **`scripts/audit-screen.mjs`** is also changed by #92, which adds the layout-shift check, and by the #71 branch, which adds the preview key. The hunks do not touch each other, but whichever merges last needs a look.
- **`.github/workflows/gates.yml`**, observation: until #45, the gates still run beside the legacy Pages build, not in front of it. A red screen audit on `main` does not stop that commit from being published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
