### PR TITLE
Serve tailored CVs only to the browser holding this run's key

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -22,7 +22,8 @@ This is a static CV/resume website built with vanilla HTML, CSS, and JavaScript.
   heuristic caching has hidden real changes more than once)
 - **Serve to another device**: `npm run serve -- --network` (by default the server answers only this
   machine; hidden paths such as `.git/` are never served, and `applications/` goes only to this machine's
-  own browser — a proxy is recognised by its headers, a raw TCP tunnel is not, so never tunnel the port)
+  own browser once it has opened the `?key=` address the server prints — a new key every run, so neither a
+  proxy nor a raw TCP tunnel reaches a tailored CV)
 - **Open CV**: Open `index.html` in a browser (no build step required)
 
 ### Formatting

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ is on disk. Do not preview with `python -m http.server`: it sends no caching hea
 shown this project a stale page more than once.
 
 The server answers only this machine. `npm run serve -- --network` opens it to another device on the network,
-and even then `applications/` is served to this machine alone.
+and even then `applications/` is served to this machine alone — and only to a browser that has opened the second
+address the server prints, the one ending in `?key=`. The key is new every run and never written to disk, so a proxy
+or a tunnel in front of the port reaches the public CV and nothing tailored.
 
 The URL chooses the CV:
 

--- a/scripts/audit-print.mjs
+++ b/scripts/audit-print.mjs
@@ -3,7 +3,7 @@ import { existsSync } from 'node:fs';
 import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createStaticServer } from './serve.mjs';
+import { createStaticServer, previewKey } from './serve.mjs';
 import { fallbackRuns, typefacesFor } from './lib/printed-typefaces.mjs';
 import { GenerationTarget } from '../core/GenerationTarget.js';
 
@@ -263,7 +263,9 @@ if (!browser) {
   process.exit(2);
 }
 
-const server = createStaticServer();
+// The browser this audit starts holds the run's key, so a tailored profile under applications/ loads (#71).
+const key = previewKey();
+const server = createStaticServer(undefined, { key });
 await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
 const port = server.address().port;
 const workspace = await mkdtemp(join(tmpdir(), 'mycv-print-'));
@@ -282,7 +284,7 @@ try {
       '--virtual-time-budget=8000',
       '--no-pdf-header-footer',
       `--print-to-pdf=${pdf}`,
-      `http://127.0.0.1:${port}/index.html?layout=${layout}&profile=${target.profile}`
+      `http://127.0.0.1:${port}/index.html?layout=${layout}&profile=${target.profile}&key=${key}`
     ]);
 
     const info = execFileSync('pdfinfo', [pdf], { encoding: 'utf8' });

--- a/scripts/audit-screen.mjs
+++ b/scripts/audit-screen.mjs
@@ -2,7 +2,7 @@ import { spawn } from 'node:child_process';
 import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
-import { createStaticServer } from './serve.mjs';
+import { createStaticServer, previewKey } from './serve.mjs';
 import { findBrowser } from './lib/find-browser.mjs';
 import { screenCopy } from './lib/screen-copy.mjs';
 import { GenerationTarget } from '../core/GenerationTarget.js';
@@ -239,7 +239,9 @@ const selection = (start, end) => `(() => {
   return text;
 })()`;
 
-const server = createStaticServer();
+// The browser this audit starts holds the run's key, so a tailored profile under applications/ loads (#71).
+const key = previewKey();
+const server = createStaticServer(undefined, { key });
 await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
 const { port } = server.address();
 const dataDir = await mkdtemp(join(tmpdir(), 'mycv-screen-'));
@@ -257,7 +259,7 @@ try {
       await chrome.send('Emulation.setDeviceMetricsOverride', { ...size, deviceScaleFactor: 1 });
       const loaded = chrome.next('Page.loadEventFired');
       await chrome.send('Page.navigate', {
-        url: `http://127.0.0.1:${port}/index.html?layout=${layout}&profile=${target.profile}&lang=${target.locale}`
+        url: `http://127.0.0.1:${port}/index.html?layout=${layout}&profile=${target.profile}&lang=${target.locale}&key=${key}`
       });
       await within(loaded, 30000, `${layout} did not load`);
       await within(

--- a/scripts/serve.mjs
+++ b/scripts/serve.mjs
@@ -1,3 +1,4 @@
+import { createHash, randomBytes, timingSafeEqual } from 'node:crypto';
 import { createServer } from 'node:http';
 import { createReadStream, realpath, realpathSync } from 'node:fs';
 import { readdir, readFile, stat } from 'node:fs/promises';
@@ -47,7 +48,8 @@ const FORWARDING_HEADERS = ['forwarded', 'via', 'x-forwarded-for', 'x-forwarded-
  * tunnel or reverse proxy running here connects from loopback for a visitor elsewhere, and says so in a
  * header; a page on another site can point its own name at 127.0.0.1 and read what it fetches, and the
  * name it used is still in Host. So the request must also be addressed to this machine. A relay that
- * forwards raw bytes adds no header and cannot be told apart: never expose the port through one.
+ * forwards raw bytes adds no header and cannot be told apart, which is why a private response also needs
+ * the key the server printed when it started (`previewKey`).
  * @param {import('node:http').IncomingMessage} request - The request
  * @returns {boolean} Whether this machine's browser sent it, with nothing in between
  */
@@ -62,6 +64,43 @@ export function isFromThisMachine({ socket, headers = {} }) {
     addressedHere &&
     !FORWARDING_HEADERS.some((header) => header in headers)
   );
+}
+
+/**
+ * A key for one run of the server: 256 random bits, made at start, printed once, held in memory and
+ * written nowhere. A relay that forwards raw bytes — `ssh -R`, `socat`, a tunnel in TCP mode — carries a
+ * visitor's request in from loopback with no header to give it away, and nothing in that request can
+ * prove where it came from (#71). Something the visitor never had can: this key, which the browser on
+ * this machine trades for a cookie.
+ * @returns {string} The key, base64url
+ */
+export function previewKey() {
+  return randomBytes(32).toString('base64url');
+}
+
+/** The cookie that carries the key, named for the port so two servers here keep their own. */
+const keyCookie = (port) => `mycv-preview-${port}`;
+
+/**
+ * Whether a value is the key, compared in constant time. Both sides are hashed first, so the
+ * comparison always runs over two 32-byte digests: neither the key's length nor the first byte that
+ * differs shows in how long it takes.
+ */
+function isKey(offered, key) {
+  if (typeof offered !== 'string') return false;
+  const digest = (value) => createHash('sha256').update(value).digest();
+  return timingSafeEqual(digest(offered), digest(key));
+}
+
+/** The value of one cookie in a Cookie header, or undefined when it is not there. */
+function cookieValue(header, name) {
+  for (const pair of (header || '').split(';')) {
+    const separator = pair.indexOf('=');
+    if (separator > 0 && pair.slice(0, separator).trim() === name) {
+      return pair.slice(separator + 1).trim();
+    }
+  }
+  return undefined;
 }
 
 /**
@@ -105,17 +144,18 @@ function resolve(url, root) {
 const realpathOf = promisify(realpath.native);
 
 /**
- * Whether a path relative to the root may be served; `local` for a request from this machine. A hidden
- * segment — `.git/`, `.claude/`, `..` — never; `applications/` only locally, compared the way a
- * filesystem may open it: case-insensitively, and without the trailing dots and spaces Windows drops.
+ * Whether a path relative to the root may be served; `trusted` for a request this machine's browser sent
+ * directly, holding the run's key. A hidden segment — `.git/`, `.claude/`, `..` — never; `applications/`
+ * only to a trusted request, compared the way a filesystem may open it: case-insensitively, and without
+ * the trailing dots and spaces Windows drops.
  * @param {string} path - A path relative to the root, as `path.relative` returns it
- * @param {boolean} local - Whether the request came from this machine
+ * @param {boolean} trusted - Whether the request came from this machine's browser with the key
  * @returns {boolean} Whether the file may be sent
  */
-export function mayServe(path, local) {
+export function mayServe(path, trusted) {
   const segments = path.split(sep);
   if (isAbsolute(path) || segments.some((segment) => segment.startsWith('.'))) return false;
-  return local || segments[0].toLowerCase().replace(/[. ]+$/, '') !== 'applications';
+  return trusted || segments[0].toLowerCase().replace(/[. ]+$/, '') !== 'applications';
 }
 
 /**
@@ -168,25 +208,34 @@ async function localManifest(root) {
  *
  * Two kinds of path are never handed to just anyone. A hidden path — `.git/`, `.claude/`, any segment
  * starting with a dot — is never served at all: the page needs none of them, and `.git/` holds the
- * whole history. `applications/`, and the manifest merged with it, are served only to this machine: a
- * tailored CV must still preview locally, and must never be readable from another device. Both rules
- * are checked against the path requested and again against where the file really is, so a link inside
- * the tree cannot carry a request past them.
+ * whole history. `applications/`, and the manifest merged with it, are served only to this machine's
+ * browser holding the run's key: a tailored CV must still preview locally, and must never be readable
+ * from another device or through a relay. Both rules are checked against the path requested and again
+ * against where the file really is, so a link inside the tree cannot carry a request past them.
+ *
+ * The key reaches the browser once, in the address the server prints: `?key=` is traded for a cookie,
+ * and the browser is sent on to the same address without it. A server handed no key makes its own,
+ * which nobody holds — so by default nothing private is served at all.
  * @param {string} root - Directory to serve
- * @param {{ isLocal?: (request: import('node:http').IncomingMessage) => boolean }} options - how to
- *   tell a request from this machine; tests hand in their own
+ * @param {object} [options] - Who may see what
+ * @param {(request: import('node:http').IncomingMessage) => boolean} [options.isLocal] - How to tell a
+ *   request from this machine; tests hand in their own
+ * @param {string} [options.key] - This run's key, from `previewKey`
  * @returns {import('node:http').Server} A server, not yet listening
  */
-export function createStaticServer(root = projectRoot, { isLocal = isFromThisMachine } = {}) {
+export function createStaticServer(
+  root = projectRoot,
+  { isLocal = isFromThisMachine, key = previewKey() } = {}
+) {
   const realRoot = realpathSync.native(root);
   const notFound = (response) =>
     response.writeHead(404, { 'Cache-Control': 'no-store' }).end('Not found');
   // Where a file really is, when the rules let it be served: a link inside the tree can point into
   // .git/, into applications/, or out of the tree altogether. Null when it is missing or refused.
-  const servable = async (path, local) => {
+  const servable = async (path, trusted) => {
     try {
       const file = await realpathOf(path);
-      return mayServe(relative(realRoot, file), local) ? file : null;
+      return mayServe(relative(realRoot, file), trusted) ? file : null;
     } catch {
       return null;
     }
@@ -194,7 +243,9 @@ export function createStaticServer(root = projectRoot, { isLocal = isFromThisMac
 
   return createServer(async (request, response) => {
     let target;
+    let address;
     try {
+      address = new URL(request.url, 'http://localhost');
       target = resolve(request.url, root);
     } catch {
       // `/%ZZ` or `//` names no path. Thrown outside the try below, it would take the server down.
@@ -206,16 +257,36 @@ export function createStaticServer(root = projectRoot, { isLocal = isFromThisMac
       return;
     }
 
-    const local = isLocal(request);
-    if (!mayServe(relative(root, target), local)) {
+    const cookieName = keyCookie(request.socket.localPort);
+    if (address.searchParams.has('key')) {
+      // The address the server printed. The key is traded for a cookie and the browser sent on without
+      // it, so it stays out of history, bookmarks and every Referer the page sends. A wrong key is
+      // dropped the same way, and buys nothing.
+      const offered = address.searchParams.get('key');
+      address.searchParams.delete('key');
+      const headers = {
+        Location: `${address.pathname}${address.search}`,
+        'Cache-Control': 'no-store'
+      };
+      if (isKey(offered, key)) {
+        headers['Set-Cookie'] = `${cookieName}=${key}; HttpOnly; SameSite=Strict; Path=/`;
+      }
+      response.writeHead(303, headers).end();
+      return;
+    }
+
+    // Both, or nothing private: a request this machine's browser sent directly, which refuses a proxy
+    // and another site's name, and the key it was handed at start, which refuses a raw relay (#71).
+    const trusted = isLocal(request) && isKey(cookieValue(request.headers.cookie, cookieName), key);
+    if (!mayServe(relative(root, target), trusted)) {
       notFound(response);
       return;
     }
 
     if (
-      local &&
+      trusted &&
       target === join(root, 'config', 'cv-manifest.json') &&
-      (await servable(target, local))
+      (await servable(target, trusted))
     ) {
       const body = await localManifest(root);
       if (body !== null) {
@@ -231,7 +302,10 @@ export function createStaticServer(root = projectRoot, { isLocal = isFromThisMac
 
     try {
       const info = await stat(target);
-      const file = await servable(info.isDirectory() ? join(target, 'index.html') : target, local);
+      const file = await servable(
+        info.isDirectory() ? join(target, 'index.html') : target,
+        trusted
+      );
       if (!file) {
         notFound(response);
         return;
@@ -250,7 +324,8 @@ export function createStaticServer(root = projectRoot, { isLocal = isFromThisMac
 
 if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) {
   const { port, host, network } = listenSettings(process.argv.slice(2), process.env);
-  createStaticServer().listen(port, host, () => {
+  const key = previewKey();
+  createStaticServer(projectRoot, { key }).listen(port, host, () => {
     console.log(`serving ${projectRoot} on ${host}:${port} with no-store`);
     console.log(
       network
@@ -258,5 +333,8 @@ if (process.argv[1] && import.meta.url === pathToFileURL(process.argv[1]).href) 
         : '  this machine only; pass --network to reach another device'
     );
     console.log(`  http://localhost:${port}/index.html?layout=nerd`);
+    console.log(
+      `  a CV from applications/ needs this run's key, once: http://localhost:${port}/index.html?key=${key}`
+    );
   });
 }

--- a/tests/DevelopmentServer.test.js
+++ b/tests/DevelopmentServer.test.js
@@ -10,7 +10,8 @@ import {
   isFromThisMachine,
   isLoopback,
   listenSettings,
-  mayServe
+  mayServe,
+  previewKey
 } from '../scripts/serve.mjs';
 
 // The development server once listened on every interface and served every file under the root:
@@ -117,7 +118,21 @@ describe('where the server listens', () => {
   });
 });
 
+// A relay that forwards raw bytes — `ssh -R`, `socat`, a tunnel in TCP mode — connects from loopback and
+// adds no header, so a visitor at its far end who writes `Host: localhost` looks exactly like this
+// machine's browser. Nothing in the request can tell them apart; only something the visitor never had
+// can: a key made when the server starts, printed once, and traded by the browser for a cookie (#71).
+describe('the key a run hands out', () => {
+  test('is new every time, and too long to guess', () => {
+    const keys = new Set(Array.from({ length: 20 }, () => previewKey()));
+
+    expect(keys.size).toBe(20);
+    for (const key of keys) expect(Buffer.from(key, 'base64url').length).toBeGreaterThanOrEqual(32);
+  });
+});
+
 describe('what the server hands out', () => {
+  const KEY = previewKey();
   let root;
   let server;
   let origin;
@@ -169,34 +184,95 @@ describe('what the server hands out', () => {
     expect((await get('/%2egit/config')).status).toBe(404);
   });
 
-  test('this machine still previews a tailored CV', async () => {
-    await start();
-    expect((await get('/applications/acme/en.json')).status).toBe(200);
-    expect((await get('/config/cv-manifest.json')).body).toContain('acme');
-  });
-
-  // A request from another machine cannot be made from a test, so the check that decides it is
-  // handed in: the same server, answering as it would to an address that is not loopback.
-  test('another machine gets neither the applications nor the manifest that lists them', async () => {
-    await start({ isLocal: () => false });
-    expect((await get('/applications/acme/en.json')).status).toBe(404);
-    const manifest = await get('/config/cv-manifest.json');
-    expect(manifest.status).toBe(200);
-    expect(manifest.body).not.toContain('acme');
-  });
-
   // A raw request, so the test sends what a browser would not: a malformed path, another Host, the
-  // headers a proxy adds.
-  const getAs = (path, headers = {}) =>
+  // headers a proxy adds, a cookie of its own making.
+  const send = (path, headers = {}) =>
     new Promise((resolve, reject) => {
       const { port } = server.address();
       httpRequest({ host: '127.0.0.1', port, path, headers }, (response) => {
-        response.resume();
-        response.on('end', () => resolve(response.statusCode));
+        let body = '';
+        response.setEncoding('utf8');
+        response.on('data', (chunk) => (body += chunk));
+        response.on('end', () =>
+          resolve({ status: response.statusCode, headers: response.headers, body })
+        );
       })
         .on('error', reject)
         .end();
     });
+  const getAs = async (path, headers) => (await send(path, headers)).status;
+
+  /** What a browser holds once it has opened the address the server printed. */
+  const cookieFor = async (key) => {
+    const { headers } = await send(`/index.html?key=${key}`);
+    return (headers['set-cookie'] || [''])[0].split(';')[0];
+  };
+
+  test('this machine previews a tailored CV once its browser holds the run’s key', async () => {
+    await start({ key: KEY });
+    const cookie = await cookieFor(KEY);
+    expect((await send('/applications/acme/en.json', { cookie })).status).toBe(200);
+    expect((await send('/config/cv-manifest.json', { cookie })).body).toContain('acme');
+  });
+
+  test('the key in the address is traded for a cookie, and the address drops it', async () => {
+    await start({ key: KEY });
+    const { port } = server.address();
+    const { status, headers } = await send(`/index.html?layout=nerd&key=${KEY}&lang=en`);
+
+    expect(status).toBe(303);
+    expect(headers.location).toBe('/index.html?layout=nerd&lang=en');
+    expect(headers['set-cookie']).toHaveLength(1);
+    const [pair, ...attributes] = headers['set-cookie'][0].split('; ');
+    expect(pair).toBe(`mycv-preview-${port}=${KEY}`);
+    expect(attributes).toEqual(expect.arrayContaining(['HttpOnly', 'SameSite=Strict', 'Path=/']));
+  });
+
+  // The acceptance case of #71, sent the way the relay would: from loopback, addressed to localhost,
+  // with no forwarding header — so the server's own check of this machine passes it.
+  test('a relay that sends Host: localhost and no header gets nothing private without the key', async () => {
+    await start({ key: KEY });
+    const relayed = { host: `localhost:${server.address().port}` };
+
+    expect(await getAs('/applications/acme/en.json', relayed)).toBe(404);
+    const manifest = await send('/config/cv-manifest.json', relayed);
+    expect(manifest.status).toBe(200);
+    expect(manifest.body).not.toContain('acme');
+  });
+
+  test('a wrong key buys no cookie, and a cookie made up opens nothing', async () => {
+    await start({ key: KEY });
+    const { port } = server.address();
+    const wrong = previewKey();
+
+    const traded = await send(`/index.html?key=${wrong}`);
+    expect(traded.status).toBe(303);
+    expect(traded.headers['set-cookie']).toBeUndefined();
+    for (const cookie of [
+      `mycv-preview-${port}=${wrong}`,
+      `mycv-preview-${port}=`,
+      `mycv-preview-1=${KEY}`
+    ]) {
+      expect(await getAs('/applications/acme/en.json', { cookie })).toBe(404);
+    }
+  });
+
+  test('a server given no key makes its own, so nothing private is served by default', async () => {
+    await start();
+    expect(await getAs('/applications/acme/en.json')).toBe(404);
+    expect((await send('/config/cv-manifest.json')).body).not.toContain('acme');
+  });
+
+  // A request from another machine cannot be made from a test, so the check that decides it is
+  // handed in: the same server, answering as it would to an address that is not loopback.
+  test('another machine gets neither the applications nor the manifest that lists them, key or not', async () => {
+    await start({ isLocal: () => false, key: KEY });
+    const cookie = await cookieFor(KEY);
+    expect(await getAs('/applications/acme/en.json', { cookie })).toBe(404);
+    const manifest = await send('/config/cv-manifest.json', { cookie });
+    expect(manifest.status).toBe(200);
+    expect(manifest.body).not.toContain('acme');
+  });
 
   test('a malformed address is refused, and the next request is still served', async () => {
     await start();
@@ -236,8 +312,8 @@ describe('what the server hands out', () => {
     writeFileSync(join(root, '.private.json'), JSON.stringify({ secret: 'private', profiles: {} }));
     rmSync(join(root, 'config', 'cv-manifest.json'));
     symlinkSync(join(root, '.private.json'), join(root, 'config', 'cv-manifest.json'));
-    await start();
-    const manifest = await get('/config/cv-manifest.json');
+    await start({ key: KEY });
+    const manifest = await send('/config/cv-manifest.json', { cookie: await cookieFor(KEY) });
     expect(manifest.body).not.toContain('private');
     expect(manifest.status).toBe(404);
   });
@@ -246,13 +322,14 @@ describe('what the server hands out', () => {
   // so in a header; a page on another site that points its own name at 127.0.0.1 still sends that
   // name as Host.
   test('a request through a proxy, or under another site’s name, is not from this machine', async () => {
-    await start();
+    await start({ key: KEY });
     const { port } = server.address();
+    const cookie = await cookieFor(KEY);
     const tailored = '/applications/acme/en.json';
-    expect(await getAs(tailored, { host: `127.0.0.1:${port}` })).toBe(200);
+    expect(await getAs(tailored, { host: `127.0.0.1:${port}`, cookie })).toBe(200);
     expect(
-      await getAs(tailored, { host: `127.0.0.1:${port}`, 'x-forwarded-for': '203.0.113.9' })
+      await getAs(tailored, { host: `127.0.0.1:${port}`, cookie, 'x-forwarded-for': '203.0.113.9' })
     ).toBe(404);
-    expect(await getAs(tailored, { host: `rebound.example:${port}` })).toBe(404);
+    expect(await getAs(tailored, { host: `rebound.example:${port}`, cookie })).toBe(404);
   });
 });

--- a/tests/LocalProfiles.test.js
+++ b/tests/LocalProfiles.test.js
@@ -6,9 +6,10 @@
  */
 import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
+import { request as httpRequest } from 'node:http';
 import { join } from 'node:path';
 import { LocalProfiles } from '../core/LocalProfiles.js';
-import { createStaticServer } from '../scripts/serve.mjs';
+import { createStaticServer, previewKey } from '../scripts/serve.mjs';
 
 const published = {
   defaultProfile: 'general',
@@ -73,12 +74,30 @@ describe('the development server merges without writing', () => {
     await rm(root, { recursive: true, force: true });
   });
 
+  /** A request as this machine's browser sends it, once it has opened the address with the key (#71). */
   async function get(path) {
-    const server = createStaticServer(root);
+    const key = previewKey();
+    const server = createStaticServer(root, { key });
     await new Promise((resolve) => server.listen(0, '127.0.0.1', resolve));
+    const send = (target, headers = {}) =>
+      new Promise((resolve, reject) => {
+        const { port } = server.address();
+        httpRequest({ host: '127.0.0.1', port, path: target, headers }, (response) => {
+          let body = '';
+          response.setEncoding('utf8');
+          response.on('data', (chunk) => (body += chunk));
+          response.on('end', () =>
+            resolve({ status: response.statusCode, headers: response.headers, body })
+          );
+        })
+          .on('error', reject)
+          .end();
+      });
     try {
-      const response = await fetch(`http://127.0.0.1:${server.address().port}${path}`);
-      return { status: response.status, body: await response.text() };
+      const traded = await send(`/index.html?key=${key}`);
+      const cookie = traded.headers['set-cookie'][0].split(';')[0];
+      const { status, body } = await send(path, { cookie });
+      return { status, body };
     } finally {
       server.closeAllConnections?.();
       await new Promise((resolve) => server.close(resolve));


### PR DESCRIPTION
> **The adversarial review has not run yet.** Codex is at its usage limit until 15 September, 09:56. The review is queued for then, and this pull request stays a draft until its findings are answered.

## What

`scripts/serve.mjs` sends `applications/`, and the manifest merged with it, only to a request it judges to come from this machine. A relay that forwards raw bytes (`ssh -R`, `socat`, a tunnel in TCP mode) connects from loopback and adds no header. A visitor at its far end who writes `Host: localhost` looked exactly like this machine's browser (#71, found by the second review of #65). Private responses now also need a key made when the server starts.

Refs #71

## How it works

- **The key.** `previewKey()` makes 256 random bits, base64url, once per run. The key is held in memory and never written anywhere.
- **Printed once.** The server prints the key in a second address: `http://localhost:8123/index.html?key=…`.
- **Traded for a cookie.** Opening that address sets the cookie `mycv-preview-<port>` (`HttpOnly; SameSite=Strict; Path=/`), and a 303 sends the browser to the same address without the key. The key stays out of history, bookmarks and the Referer header. A wrong key is dropped the same way and sets nothing.
- **Both conditions.** A private response needs `isFromThisMachine`, as before, and a cookie matching the key.
  - **Constant time.** The comparison hashes both sides with SHA-256 and runs `timingSafeEqual` over the two digests.
- **No key, nothing private.** A server handed no key makes its own, which nobody holds, so by default nothing private is served.
- **The audits hold a key.** `audit:print` and `audit:screen` each make one, hand it to the server they start, and put it in the address they open.

## What still works without the key

Everything public: the page, every published profile, the committed manifest. The desktop preview (`.claude/launch.json`, `node scripts/serve.mjs 8123`) opens the public CV exactly as before. A tailored CV needs the printed address once per run. `README.md` and `CLAUDE.md` say so.

## Proof

- **`tests/DevelopmentServer.test.js`:**
  - **The acceptance case.** A relay sending `Host: localhost` from loopback, with no forwarding header, gets neither `applications/` nor the merged manifest.
  - **The trade.** The key in the address buys a cookie with those attributes, and the redirect drops the key.
  - **Wrong keys and cookies.** A wrong key buys no cookie. A made-up cookie, an empty one, and the right key under another port's cookie name all open nothing.
  - **The machine check still stands.** Another machine holding the cookie gets nothing. So does a proxy, or another site's name, with the cookie.
  - **Defaults.** A server handed no key serves nothing private. Twenty keys are twenty different values of at least 32 bytes.
- **`tests/LocalProfiles.test.js`** now reaches the merged manifest and the local profile the way a browser does: with the key.
- **Through the real browser.** A throwaway profile, `applications/zz-preview/en.json` (the general profile under another name), was audited with both browser audits:
  - `npm run audit:print -- --profile=…` scored 12/12 on all three layouts;
  - `npm run audit:screen -- --profile=…` scored 5/5 at both widths.
  - Both audits check against the tailored name, so a page that fell back to the public profile, or could not load the private one, would have failed. The directory was removed afterwards, and it is gitignored in any case.
- **Startup output:**
  ```
  serving … on 127.0.0.1:8197 with no-store
    this machine only; pass --network to reach another device
    http://localhost:8197/index.html?layout=nerd
    a CV from applications/ needs this run's key, once: http://localhost:8197/index.html?key=<43 characters>
  ```
- **Gates.** `npm test`: 516 passed.

## Found on the way

Proving this found a separate defect. On a tailored profile that was never built, both browser audits crash writing their report, because `applications/<name>/out/` does not exist yet. Filed as #94 and not fixed here: it is outside this ticket.

## Reviews

- **Adversarial (codex-cli):** not run yet; queued for the usage-limit reset on 15 September.
- **Product review:** skipped. The diff touches the server, two audits, tests and docs, not what the CV says or how it renders.

## Self-review

- **`scripts/serve.mjs`: the key is a secret, and it is printed to the terminal.** Anyone who has it can make the trade through a relay too. It is shown only to whoever started the server, and it changes every run. Observation.
- **`scripts/audit-screen.mjs`** is also changed by #93 (how the browser is closed) and #92 (the layout-shift check). The hunks do not touch each other, but whichever merges last needs a look.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
