### PR TITLE
Keep withdrawn claims withdrawn, and the reference fixture on the profile

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,20 @@ self-rating into the main evidence of competence.
 - Removing CSS, icons, or graphical markers does not remove skill names or proficiency meaning.
 - The CV does not claim precision that the underlying self-assessment cannot justify.
 
+## Qualifications and certifications
+
+- **A foreign qualification uses the issuer's wording,** never a German- or English-style abbreviation
+  the issuer does not award. The programme at the University of Pisa is a _First Level Professional
+  Master's Programme in Mobile Applications Development_, and an abbreviated degree in its place claims
+  one nobody conferred. When the name holds a word the target market reads as a degree level —
+  _Master's_ — the rendered text states its scope (#48).
+- **A certification's name is the title on the page its link opens.** Lower tiers it includes go in
+  brackets after it — `Android Enterprise Expert (incl. Associate, Professional)` — never as equal names
+  in one entry, which reads as a credential nobody issues.
+- **A certification may lose its description only if its name line still states the subject.** Page
+  budget took the description of iOS Lead Essentials; its subject moved into brackets on the name line,
+  `iOS Lead Essentials (TDD, Clean Architecture)`, rather than disappearing.
+
 ## The loop's role system
 
 The ticket-loop skill defers to the project's own role system where one exists: _"If the project
@@ -110,6 +124,24 @@ skipped and why, rather than skipping it silently.
 The review runs on the **rendered artefact**, not the diff. Run `npm run build:pdf` first;
 `cv-reviewer` needs a PDF to extract text from, and a review of the source that never looked at
 the output is not a product review.
+
+### Linked pages are part of the CV
+
+`profiles/<profile>/<locale>.json` is the single source of truth. The web CV and the PDFs are built
+from it, and a copy of the CV kept by hand anywhere else is stale by construction. So the CV links only
+to surfaces built from the profile, and to third-party profiles that are not a second copy of it —
+GitHub, LinkedIn. A second copy is not kept in step; it is unlinked. The Google Sites page that still
+claimed the withdrawn degree was unlinked on #47 rather than corrected, and a blog there can be linked
+once it is a blog.
+
+When a ticket corrects a factual claim — a degree, a date, a level, a number of years — the product
+review checks every third-party page the CV links to for the old wording before the merge, and the pull
+request says what it found. That check is by hand: LinkedIn and XING need a login.
+
+Inside the repository the check is not by hand. `tests/WithdrawnClaimsStayWithdrawn.test.js` lists every
+withdrawn claim with its reason and fails on any tracked file that still makes one, so withdrawing a
+claim means adding it there. `tests/ReferenceFixtureFollowsProfile.test.js` holds the recoverability
+tests' reference fixture to the profile: it drifted once while every test built on it kept passing.
 
 ### The default review target
 

--- a/tests/ReferenceFixtureFollowsProfile.test.js
+++ b/tests/ReferenceFixtureFollowsProfile.test.js
@@ -1,0 +1,54 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync } from 'node:fs';
+
+// tests/fixtures/ats/clean-english.txt is the recoverability tests' reference: they diff what the parser
+// recovers from it against profiles/general/en.json. It was written by hand, and it drifted from the
+// profile — a withdrawn degree, a German level the profile had already corrected — while every test built
+// on it kept passing (#50). Its education and its languages are the profile's, line for line.
+const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+const profile = JSON.parse(read('profiles/general/en.json'));
+const labels = JSON.parse(read('locales/en/cv.json')).sections;
+const fixture = read('tests/fixtures/ats/clean-english.txt');
+
+/** The non-empty lines between one heading of the fixture and the next. */
+const between = (text, heading, next) => {
+  const lines = text.split('\n').map((line) => line.trim());
+  const start = lines.indexOf(heading);
+  const end = lines.indexOf(next, start + 1);
+  return start < 0 || end < 0 ? null : lines.slice(start + 1, end).filter(Boolean);
+};
+
+/** What the fixture's two sections hold. */
+const written = (text) => ({
+  education: between(text, labels.education, labels.languages),
+  languages: between(text, labels.languages, labels.certifications)
+});
+
+/** What the profile says they hold, in the form the extracted PDF writes it. */
+const authored = (cv) => ({
+  education: cv.education.flatMap(({ degree, school, period }) => [
+    degree,
+    `${school} · ${period}`
+  ]),
+  languages: cv.languages.map(({ name, level }) => `${name}: ${level}`)
+});
+
+describe('the reference fixture follows the profile', () => {
+  test('the check finds a line changed away from the profile', () => {
+    const [line] = authored(profile).languages;
+    const drifted = fixture.replace(line, `${line} (drifted)`);
+
+    expect(drifted).not.toBe(fixture);
+    expect(written(drifted)).not.toEqual(authored(profile));
+  });
+
+  test('its education lines are the profile’s', () => {
+    expect(written(fixture).education).toEqual(authored(profile).education);
+  });
+
+  test('its language lines are the profile’s', () => {
+    expect(written(fixture).languages).toEqual(authored(profile).languages);
+  });
+});

--- a/tests/WithdrawnClaimsStayWithdrawn.test.js
+++ b/tests/WithdrawnClaimsStayWithdrawn.test.js
@@ -1,0 +1,89 @@
+/**
+ * @jest-environment node
+ */
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// A claim the CV withdrew came back without anything noticing: the degree the PDF no longer claimed was
+// still in six public test fixtures under the candidate's name, and on the page the CV linked to (#50).
+// Withdrawing a claim means adding it here, with the reason.
+const WITHDRAWN = [
+  {
+    text: 'M.Sc. Mobile Application',
+    reason:
+      'The University of Pisa programme is a First Level Professional Master’s Programme, and the ' +
+      'issuer does not award it as an M.Sc. (#47).'
+  },
+  {
+    text: 'A2 — currently studying',
+    reason: 'German is at A1 (#47).'
+  }
+];
+
+// Where a withdrawn string may stay, and why.
+const EXEMPT = new Map([
+  [
+    'tests/WithdrawnClaimsStayWithdrawn.test.js',
+    'the list itself, which has to name what it looks for'
+  ]
+]);
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+
+/**
+ * Every withdrawn claim a set of files still makes, as `path: claim`, whatever its case.
+ * @param {{ path: string, content: string }[]} files - Text files and what they hold
+ * @returns {string[]} The claims found, outside the exemptions
+ */
+const stillClaimed = (files) =>
+  files
+    .filter(({ path }) => !EXEMPT.has(path))
+    .flatMap(({ path, content }) =>
+      WITHDRAWN.filter(({ text }) => content.toLowerCase().includes(text.toLowerCase())).map(
+        ({ text }) => `${path}: ${text}`
+      )
+    );
+
+/**
+ * The tracked text files. A binary file is skipped: the PDFs compress their text, so reading their
+ * bytes would find nothing, and what they say is audit:pdf's and audit:ats's to check.
+ */
+const trackedText = () =>
+  execFileSync('git', ['ls-files', '-z'], { cwd: root, encoding: 'utf8' })
+    .split('\0')
+    .filter(Boolean)
+    .flatMap((path) => {
+      let bytes;
+      try {
+        bytes = readFileSync(join(root, path));
+      } catch {
+        return [];
+      }
+      return bytes.subarray(0, 8000).includes(0) ? [] : [{ path, content: bytes.toString('utf8') }];
+    });
+
+describe('a withdrawn claim stays withdrawn', () => {
+  test('the check finds one planted in a profile, in any case', () => {
+    const planted = [
+      {
+        path: 'profiles/general/en.json',
+        content: '{"degree": "m.sc. mobile applications development"}'
+      }
+    ];
+
+    expect(stillClaimed(planted)).toEqual(['profiles/general/en.json: M.Sc. Mobile Application']);
+  });
+
+  test('every withdrawn claim says why it was withdrawn', () => {
+    for (const { reason } of WITHDRAWN) expect(reason.trim()).not.toBe('');
+  });
+
+  test('no tracked file makes one outside its exemption', () => {
+    const files = trackedText();
+
+    expect(files.length).toBeGreaterThan(100);
+    expect(stillClaimed(files)).toEqual([]);
+  });
+});


### PR DESCRIPTION
> **The adversarial review has not run yet.** Codex is at its usage limit until 15 September, 09:56. The review is queued for then, and this pull request stays a draft until its findings are answered.

## What

The product review on #47 found two things nothing had noticed:

- **A withdrawn degree still in the repository.** The PDF fix did not reach six public test fixtures, or the page the CV linked to.
- **A reference fixture drifting from the profile.** The recoverability tests' reference disagreed with the profile, while every test built on it kept passing.

The fixtures were corrected on #47. This adds what would catch the next one.

Refs #50

## AGENTS.md

- **Linked pages are part of the CV**, under *When the product review runs*. Written from the owner's principle on the ticket:
  - the profile is the single source of truth;
  - the CV links only to surfaces built from it, and to third-party profiles;
  - a second copy of the CV is unlinked, not kept in step;
  - a correction of a factual claim checks those third-party pages by hand before the merge.
- **Qualifications and certifications**, beside the skills rules:
  - a foreign qualification in the issuer's wording, with its scope stated when the market reads a degree level into it (#48);
  - the owner's two rules from #52, on certification names and descriptions.

## Tests, each shown to fail

- **`tests/WithdrawnClaimsStayWithdrawn.test.js`** holds the withdrawn claims, each with its reason, starting with the two the ticket names. It scans every tracked text file outside one named exemption, the list itself. Its first test plants a withdrawn string, in another case, and the scan finds it.
- **`tests/ReferenceFixtureFollowsProfile.test.js`** requires the Education and Languages lines of `tests/fixtures/ats/clean-english.txt` to be the profile's, line for line, under the labels `locales/en/cv.json` gives them. Its first test changes one language line away from the profile, and the comparison fails.
- **Red on the real tree.** Setting German back to `A2 — currently studying` in `profiles/general/en.json` fails both tests: the planted withdrawn string, and a fixture that no longer matches the profile. The profile was restored afterwards.
- **Green today.** Both pass on the tree as it is: no withdrawn claim is left, and the fixture agrees with the profile.
- **Gates.** `npm test`: 517 passed.

## Not done here

- **Binary files are not scanned.** The PDFs compress their text, so a scan of their bytes would find nothing. What the PDFs say is for `audit:pdf` and `audit:ats` to check.
- **Third-party pages stay a manual check,** as the ticket says: LinkedIn and XING need a login.

## Reviews

- **Adversarial (codex-cli):** not run yet; queued for the usage-limit reset on 15 September.
- **Product review:** skipped. The diff touches `AGENTS.md` and tests, not what the CV says or how it renders.

## Self-review

- **Coordination.** A peer session has two unpushed branches, and this pull request should merge cleanly with both:
  - they rewrite the Cortado entry, regenerate `clean-english.txt` from the profile, and add a paragraph after `AGENTS.md` line 25;
  - their new title and skill name are not on the withdrawn list;
  - the additions here sit further down `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
