### PR TITLE
Write down GitHub Flow, and guard main alone

### DIFF
--- a/.agents/harness/guards.json
+++ b/.agents/harness/guards.json
@@ -1,8 +1,7 @@
 {
   "_comment": "Policy for this project. Version it. Review the branches: the default branch is not necessarily the one to protect.",
   "protected": [
-    "^main$",
-    "^release/.+$"
+    "^main$"
   ],
   "noncode": [
     "^(CLAUDE|AGENTS)\\.md$",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,33 @@ locations and in the Playwright cache; `CHROME_PATH` overrides. When it finds no
 and checks nothing**, because an audit that did not run must never read as a pass — the same
 mistake the grayscale check made when its filename pattern matched no files for weeks.
 
+## Branches, and how a change reaches the public CV
+
+**GitHub Flow**, chosen by the owner on #44:
+
+- **`main` is what is published.** GitHub Pages serves it: a commit on `main` is a commit a recruiter
+  can open.
+- **Every change reaches `main` by pull request,** from a short-lived branch cut from `main` and named
+  `{prefix}/{ticket}-{slug}`, as the ticket loop already names it, and merges once the gates in
+  `.github/workflows/gates.yml` are green.
+- **No other branch lives long.** No `develop`, no `release/*`, no integration branch. `cv-2026-update`
+  lived for months: pull request #31 merged into it twenty-one seconds after it had been merged into
+  `main`, and sprint 3 never reached the default branch (#40). A release, when one is worth naming, is a
+  tag on `main`.
+- **An urgent fix takes the same road:** a branch from `main`, a pull request, the gates, a merge. A
+  second road to the public CV would be a road without gates, and #63 is what that costs: a merge nobody
+  tested published an empty CV for 48 minutes.
+- **`.agents/harness/guards.json` protects `^main$`**, and nothing else, so the local hook refuses a
+  direct commit to `main`. The same rule on GitHub — a ruleset requiring a pull request and the gates —
+  is a repository setting, and the owner's to switch on. `tests/BranchingModel.test.js` fails when the
+  guard and this section stop agreeing.
+
+Until #45 deploys from CI after the gates, GitHub Pages still builds every push to `main` on its own. A
+green gate is the rule for merging, not yet what publishes.
+
+One branch predates the model and stays: `archive/print-pagination-engine` keeps the print pagination
+engine that was removed reachable. It is never merged and never deployed.
+
 ## What the browser caches, and what it does not
 
 The stylesheets and the entry script carry a `?v=` in `index.html` and change name on

--- a/tests/BranchingModel.test.js
+++ b/tests/BranchingModel.test.js
@@ -1,0 +1,22 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync } from 'node:fs';
+
+// The branching model is GitHub Flow (#44): main is what is published, and no other branch lives long.
+// The local guard and AGENTS.md say so together, or one of them is wrong — the guard used to protect
+// release/* too, for a model this project never adopted.
+const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+
+describe('the branching model', () => {
+  test('the local guard protects main, and only main', () => {
+    expect(JSON.parse(read('.agents/harness/guards.json')).protected).toEqual(['^main$']);
+  });
+
+  test('AGENTS.md names the model and the branch the guard protects', () => {
+    const agents = read('AGENTS.md');
+
+    expect(agents).toMatch(/\*\*GitHub Flow\*\*/);
+    expect(agents).toContain('`.agents/harness/guards.json` protects `^main$`');
+  });
+});


### PR DESCRIPTION
> **The adversarial review has not run yet.** Codex is at its usage limit until 15 September, 09:56. The review is queued for then, and this pull request stays a draft until its findings are answered.

## What

The owner chose GitHub Flow on #44, and nothing in the repository said so. This writes the choice down where the project's rules live, and makes the local guard say the same thing.

Refs #44

## Changes

- **`AGENTS.md`**, a new section, *Branches, and how a change reaches the public CV*:
  - `main` is what is published;
  - every change reaches `main` by pull request, from a short-lived `{prefix}/{ticket}-{slug}` branch, once the gates are green;
  - no other branch lives long, and a release is a tag on `main`;
  - an urgent fix takes the same road;
  - the one branch kept from before the model, and why it is kept.
- **`.agents/harness/guards.json`**: `protected` is now `^main$` only. `^release/.+$` described a model this project never adopted.
- **`tests/BranchingModel.test.js`**: the guard protects exactly `main`, and `AGENTS.md` names that model. Changing one without the other fails the test; it was red before this change and green after.

## Still open on #44: the owner's to decide

- **The server-side ruleset on `main`**, requiring a pull request and the gates as checks. This is a repository setting, so it is not done here.
- **The leftover branches:**
  - `feat/56-nerd-mode-swift-editor` (merged through #66) and `fix/63-public-cv-duplicate-declaration` (merged through #64) can be deleted;
  - `archive/print-pagination-engine` stays, as its name says;
  - `cv-2026-update`, `feat/advert-matching-and-cover-letter` and `fix/37-tickets-close-by-hand` are already gone.

  Nothing is deleted here.

## Proof

- **Gates.** `npm test`: 513 passed.

## Reviews

- **Adversarial (codex-cli):** not run yet; queued for the usage-limit reset on 15 September.
- **Product review:** skipped. The diff touches `AGENTS.md`, the harness guard and a test, not what the CV says or how it renders.

## Self-review

- **`AGENTS.md`:** until #45 lands, GitHub Pages still builds every push to `main` on its own. "Once the gates are green" is the rule for merging, not yet the mechanism that publishes, and the section says so.
- **Coordination:** #50 also adds sections to `AGENTS.md`, in other places. The two should merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
