### PR TITLE
Write an audit's report even where no build made its directory

### DIFF
--- a/scripts/audit-print.mjs
+++ b/scripts/audit-print.mjs
@@ -1,9 +1,10 @@
 import { execFileSync, spawn } from 'node:child_process';
 import { existsSync } from 'node:fs';
-import { mkdtemp, readdir, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readdir, readFile, rm } from 'node:fs/promises';
 import { homedir, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createStaticServer, previewKey } from './serve.mjs';
+import { writeReport } from './lib/write-report.mjs';
 import { fallbackRuns, typefacesFor } from './lib/printed-typefaces.mjs';
 import { GenerationTarget } from '../core/GenerationTarget.js';
 
@@ -409,7 +410,7 @@ const report = [
   'the data did not write, and every run of text set in a typeface its layout prints in.'
 ].join('\n');
 
-await writeFile(new URL(target.reportPath('PRINT_AUDIT.md'), projectUrl), `${report}\n`);
+await writeReport(new URL(target.reportPath('PRINT_AUDIT.md'), projectUrl), `${report}\n`);
 console.log(report);
 
 if (failures.length) {

--- a/scripts/audit-screen.mjs
+++ b/scripts/audit-screen.mjs
@@ -1,8 +1,9 @@
 import { spawn } from 'node:child_process';
-import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { createStaticServer, previewKey } from './serve.mjs';
+import { writeReport } from './lib/write-report.mjs';
 import { findBrowser } from './lib/find-browser.mjs';
 import { screenCopy } from './lib/screen-copy.mjs';
 import { RECORD_LAYOUT_SHIFTS, layoutShift } from './lib/layout-shift.mjs';
@@ -344,7 +345,7 @@ const report = [
   'while it loads — every layout shift from navigation to fonts ready, added up, below 0.1.'
 ].join('\n');
 
-await writeFile(new URL(target.reportPath('SCREEN_AUDIT.md'), projectUrl), `${report}\n`);
+await writeReport(new URL(target.reportPath('SCREEN_AUDIT.md'), projectUrl), `${report}\n`);
 console.log(report);
 
 if (failures.length) {

--- a/scripts/lib/write-report.mjs
+++ b/scripts/lib/write-report.mjs
@@ -1,0 +1,19 @@
+import { mkdir, writeFile } from 'node:fs/promises';
+import { dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/**
+ * Writes an audit's report, making its directory first.
+ *
+ * A tailored profile's report goes beside the profile, in `applications/<name>/out/`, and only
+ * `npm run build:pdf` used to create that directory. The print and screen audits need no build. On a
+ * profile that was never built they checked every layout and then crashed writing the report: exit 1,
+ * the code for a failed check, and no report at all (#94).
+ * @param {URL} file - Where the report goes
+ * @param {string} text - The report
+ * @returns {Promise<void>} Resolves once the report is on disk
+ */
+export async function writeReport(file, text) {
+  await mkdir(dirname(fileURLToPath(file)), { recursive: true });
+  await writeFile(file, text);
+}

--- a/tests/WriteReport.test.js
+++ b/tests/WriteReport.test.js
@@ -1,0 +1,38 @@
+/**
+ * @jest-environment node
+ */
+import { mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import { writeReport } from '../scripts/lib/write-report.mjs';
+
+describe('an audit report', () => {
+  let root;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'report-'));
+  });
+
+  afterEach(() => {
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // A tailored profile that was never built has no out/ directory yet, and its report goes there (#94).
+  test('is written where no directory exists yet', async () => {
+    const file = pathToFileURL(join(root, 'applications', 'acme', 'out', 'PRINT_AUDIT.md'));
+
+    await writeReport(file, '# Print quality matrix\n');
+
+    expect(readFileSync(file, 'utf8')).toBe('# Print quality matrix\n');
+  });
+
+  test('replaces the report an earlier run wrote', async () => {
+    const file = pathToFileURL(join(root, 'SCREEN_AUDIT.md'));
+
+    await writeReport(file, 'earlier\n');
+    await writeReport(file, 'later\n');
+
+    expect(readFileSync(file, 'utf8')).toBe('later\n');
+  });
+});


### PR DESCRIPTION
> **The adversarial review has not run yet.** Codex is at its usage limit until 15 September, 09:56. The review is queued for then, and this pull request stays a draft until its findings are answered.

## What

Run on a tailored profile that was never built, `npm run audit:print` and `npm run audit:screen` checked every layout, then crashed writing their report. The report belongs in `applications/<name>/out/`, which only `npm run build:pdf` created. The crash exited 1, the code for a failed check, and no report was written. Found while proving #71.

Refs #94

## Changes

- **`scripts/lib/write-report.mjs`:** `writeReport` makes the report's directory, then writes the report.
- **`scripts/audit-print.mjs` and `scripts/audit-screen.mjs`:** both write their report through it.

The PDF and ATS audits are unchanged. They read the PDFs a build wrote into that same directory, so for them it always exists.

## Proof

- **The helper, red to green.** `tests/WriteReport.test.js` writes a report into a directory that does not exist yet, and replaces a report an earlier run wrote. It was red before the helper existed.
- **A real run.** A throwaway profile, `applications/zz-report/en.json` (the general profile under another name), with no `out/` directory:
  - `npm run audit:screen -- --profile=…` exits 0 and writes `applications/zz-report/out/SCREEN_AUDIT.md`: 6/6 at both widths;
  - `npm run audit:print -- --profile=…` exits 0 and writes `PRINT_AUDIT.md`: 12/12 on all three layouts;
  - the profile was removed afterwards, and it is gitignored in any case.
- **Gates.** `npm test`: 540 passed.

## Reviews

- **Adversarial (codex-cli):** not run yet; queued for the usage-limit reset on 15 September.
- **Product review:** skipped. The diff touches audit scripts and a test, not what the CV says or how it renders.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
