### PR TITLE
Publish from the gates workflow, and only after every gate

### DIFF
--- a/.github/workflows/gates.yml
+++ b/.github/workflows/gates.yml
@@ -10,10 +10,11 @@ on:
 permissions:
   contents: read
 
-# A newer push to the same branch makes the run for the older one moot.
+# A newer push to the same branch makes the run for the older one moot, except on main: every run there
+# ends in a deploy, so a newer run waits for the older one to finish instead of cancelling it mid-publish.
 concurrency:
   group: gates-${{ github.ref }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' }}
 
 jobs:
   gates:
@@ -68,6 +69,24 @@ jobs:
         env:
           CHROME_PATH: /usr/bin/google-chrome
 
+      # What GitHub Pages publishes: the tree as committed, with the PDFs this run built from the committed
+      # profile and has just audited, never files built on someone's machine (#43). Only on main, the one
+      # branch that is published (#44), and only when every step above passed.
+      - name: Assemble the site
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          # applications/ is gitignored, so a checkout never has one. Make sure rather than trust it.
+          test ! -e applications
+          rsync -a --exclude='.*' --exclude=node_modules --exclude=generated/qa ./ "$RUNNER_TEMP/site/"
+          test ! -e "$RUNNER_TEMP/site/applications"
+          ls "$RUNNER_TEMP/site"
+
+      - name: Hand the site to GitHub Pages
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/upload-pages-artifact@v5
+        with:
+          path: ${{ runner.temp }}/site/
+
       - name: Collect the reports this run wrote
         if: always()
         run: |
@@ -82,3 +101,30 @@ jobs:
           name: audit-reports
           path: ${{ runner.temp }}/audit-reports/
           if-no-files-found: ignore
+
+  # Publishing is what a green run on main does, never a second road: this job runs only for a push to
+  # main, only after every step of `gates` passed, and deploys the site that run assembled (#45). GitHub
+  # Pages builds nothing on its own any more; its source is this workflow.
+  deploy:
+    needs: gates
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    permissions:
+      contents: read
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    # One deploy at a time, whatever starts it: a second waits for the first rather than cancelling it.
+    concurrency:
+      group: pages
+      cancel-in-progress: false
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5
+
+      - name: Say which commit went live
+        run: echo "Published $GITHUB_SHA to ${{ steps.deployment.outputs.page_url }}" >> "$GITHUB_STEP_SUMMARY"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -298,8 +298,11 @@ mistake the grayscale check made when its filename pattern matched no files for 
   is a repository setting, and the owner's to switch on. `tests/BranchingModel.test.js` fails when the
   guard and this section stop agreeing.
 
-Until #45 deploys from CI after the gates, GitHub Pages still builds every push to `main` on its own. A
-green gate is the rule for merging, not yet what publishes.
+A merge to `main` is what publishes. `.github/workflows/gates.yml` runs every gate on that commit and
+only then deploys it to GitHub Pages: the tree as committed, with the PDFs that run built from the
+committed profile and audited. A red gate publishes nothing. The Pages source is that workflow, not the
+branch, so the legacy build that published every push to `main` on its own is gone, and with it the
+road #63 took (#45).
 
 One branch predates the model and stays: `archive/print-pagination-engine` keeps the print pagination
 engine that was removed reachable. It is never merged and never deployed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,12 @@ This is a static CV/resume website built with vanilla HTML, CSS, and JavaScript.
 - **Audit what the browser prints**: `npm run audit:print` (needs Chrome; `CHROME_PATH` overrides)
 - **Audit what a reader copies off the screen**: `npm run audit:screen` (needs Chrome; `CHROME_PATH` overrides)
 
+### Publishing
+
+- **A merge to `main` publishes.** `.github/workflows/gates.yml` runs every gate on it, then its `deploy`
+  job hands GitHub Pages the tree with the PDFs that run built. A red gate publishes nothing, and nothing
+  else publishes: the Pages source is the workflow, not the branch.
+
 ## Architecture
 
 Ports and adapters. `AGENTS.md` holds the product rules and the settled decisions; this is the map.

--- a/README.md
+++ b/README.md
@@ -103,6 +103,6 @@ adds a cover letter. A tailored CV leaves the machine only as an attached PDF.
 ## Working on it
 
 Work is tracked in GitHub issues and lands through pull requests. Every push and pull request runs the gates in GitHub Actions,
-`.github/workflows/gates.yml`: formatting, the tests, and the PDF, ATS and print audits. A red audit fails the build. A commit references its ticket with `Refs #N` and
+`.github/workflows/gates.yml`: formatting, the tests, and the PDF, ATS, print and screen audits. A red audit fails the build, and a merge to `main` is published to GitHub Pages only after every gate on it has passed. A commit references its ticket with `Refs #N` and
 never closes it — a person closes a ticket after the work has been audited, and `tests/TicketsCloseByHand.test.js`
 fails on a closing keyword.

--- a/tests/PublishingWaitsForTheGates.test.js
+++ b/tests/PublishingWaitsForTheGates.test.js
@@ -1,0 +1,84 @@
+/**
+ * @jest-environment node
+ */
+import { readdirSync, readFileSync } from 'node:fs';
+
+// A merge to main publishes, and nothing else does (#45). GitHub Pages deploys the site the gates job
+// assembled, only for a push to main, and only after every gate passed. #63 is what a road around the
+// gates cost: an empty public CV for 48 minutes. Prettier lays the workflow out, so its jobs and steps
+// can be read as text, without a YAML parser the project does not depend on.
+const workflows = new URL('../.github/workflows/', import.meta.url);
+const gates = readFileSync(new URL('gates.yml', workflows), 'utf8');
+const ON_MAIN = "if: github.event_name == 'push' && github.ref == 'refs/heads/main'";
+
+/** One job's lines, from its key under `jobs:` to the next job's key. */
+const job = (text, name) => {
+  const start = text.indexOf(`\n  ${name}:\n`);
+  if (start < 0) return null;
+  const rest = text.slice(start + 1);
+  const next = rest.slice(1).search(/\n {2}[a-z][\w-]*:\n/);
+  return next < 0 ? rest : rest.slice(0, next + 2);
+};
+
+/** What would let the site go live without every gate, or anywhere but from main. */
+const problems = (text) => {
+  const gatesJob = job(text, 'gates');
+  const deploy = job(text, 'deploy');
+  if (!gatesJob || !deploy) return ['a gates or a deploy job is missing'];
+
+  const found = [];
+  if (!/^ {4}needs: gates$/m.test(deploy)) found.push('deploy does not wait for gates');
+  if (!deploy.includes(`\n    ${ON_MAIN}\n`)) found.push('deploy is not limited to a push to main');
+  if (/always\(\)|failure\(\)|cancelled\(\)|continue-on-error/.test(deploy)) {
+    found.push('deploy can follow a failed gate');
+  }
+  if (/continue-on-error/.test(gatesJob)) found.push('a gate can fail without failing its job');
+  if (/^ {2}cancel-in-progress: true$/m.test(text))
+    found.push('a newer run can cancel a deploy on main');
+
+  const upload = gatesJob.indexOf('uses: actions/upload-pages-artifact@');
+  if (upload < 0) return [...found, 'gates hands Pages no site'];
+  const uploadStep = gatesJob.slice(gatesJob.lastIndexOf('- name:', upload), upload);
+  if (!uploadStep.includes(ON_MAIN)) found.push('the site is handed over beyond main');
+  if (upload < gatesJob.indexOf('run: npm run audit:screen')) {
+    found.push('the site is handed over before the last audit');
+  }
+  return found;
+};
+
+describe('publishing waits for the gates', () => {
+  test('the check finds a deploy that does not wait, or runs whatever happened', () => {
+    const impatient = gates.replace('    needs: gates\n', '');
+    const unconditional = gates.replace(
+      `\n    ${ON_MAIN}\n    runs-on`,
+      '\n    if: always()\n    runs-on'
+    );
+
+    expect(impatient).not.toBe(gates);
+    expect(unconditional).not.toBe(gates);
+    const hasty = gates.replace(/^( {2}cancel-in-progress:).*$/m, '$1 true');
+    expect(hasty).not.toBe(gates);
+    expect(problems(hasty)).toContain('a newer run can cancel a deploy on main');
+    expect(problems(impatient)).toContain('deploy does not wait for gates');
+    expect(problems(unconditional)).toEqual(
+      expect.arrayContaining([
+        'deploy is not limited to a push to main',
+        'deploy can follow a failed gate'
+      ])
+    );
+  });
+
+  test('the site goes live from main only, after every gate on that commit passed', () => {
+    expect(problems(gates)).toEqual([]);
+  });
+
+  test('no other workflow publishes', () => {
+    const others = readdirSync(workflows)
+      .filter((name) => name !== 'gates.yml')
+      .filter((name) =>
+        /deploy-pages|upload-pages-artifact/.test(readFileSync(new URL(name, workflows), 'utf8'))
+      );
+
+    expect(others).toEqual([]);
+  });
+});


### PR DESCRIPTION
> **The adversarial review has not run yet.** Codex is at its usage limit until 15 September, 09:56. The review is queued for then, and this pull request stays a draft until its findings are answered.

> **Merging needs one setting switched at the same moment.** The GitHub Pages source goes from the legacy build of `main` to GitHub Actions; the owner approved that switch. Merged without it, the deploy job fails and the legacy build keeps publishing every push, ungated.

## What

GitHub Pages built every push to `main` on its own, whether or not a gate had run. On 2026-09-11 that published an empty CV for 48 minutes (#63). Now a green run on `main` is the only thing that publishes.

Refs #45

## How

- **The `gates` job assembles the site**, on a push to `main`, after the last audit:
  - the tree as committed, with the PDFs this run built from the committed profile;
  - `generated/qa/`, dot-files and `node_modules/` are left out;
  - it checks that no `applications/` exists, before and after;
  - it hands the site to Pages with `actions/upload-pages-artifact@v5`.
- **The `deploy` job publishes it:**
  - `needs: gates`, and only for a push to `main`;
  - `actions/deploy-pages@v5` into the `github-pages` environment, which accepts only `main`;
  - the run summary names the commit that went live.
- **Order.** Runs on `main` no longer cancel each other: a newer run waits instead of cancelling a deploy midway. Deploys also share one concurrency group.
- **Docs.** `AGENTS.md` (the branching section from #97), `CLAUDE.md` and `README.md` say how a change reaches the public CV. The README also catches up with #89: the gates include the screen audit.

## Proof on the real pipeline

A throwaway branch, `proof/45-red-gate-publishes-nothing`, with the deploy conditions opened to it and the contact card's pin written back into the page:

| | |
|---|---|
| **Run** | [34725563188](https://github.com/PigLardLord/cv-giovanni/actions/runs/34725563188) |
| **Gates** | failure at *Audit what a reader copies off the screen*: `nothingUnwritten`, with `"📍 Bad Liebenstein, Thuringia, Germany"` on four renders. Every earlier step green. |
| **Assemble the site**, **Hand the site to GitHub Pages** | skipped |
| **Deploy** | skipped |
| **`github-pages` deployments** | unchanged before and after; the latest is still `7cf53a9`, the merge of #97 |

Had the gates passed, that branch still could not have published: the environment's deployment branch policy admits `main` only. The throwaway branch has been deleted; the run remains.

The green half, a merge that publishes and names its commit, can only happen on `main`. The merge itself will show it, and its run will be added to this thread.

**Tests.** `tests/PublishingWaitsForTheGates.test.js` fails when:

- the deploy stops waiting for the gates;
- the deploy runs beyond a push to `main`;
- a newer run can cancel a deploy;
- the site is handed over before the last audit.

Its first test makes those changes to the real workflow and checks each is caught. The test was red before the change and green after.

**Gates.** `npm test`: 541 passed.

## Reviews

- **Adversarial (codex-cli):** not run yet; queued for the usage-limit reset on 15 September.
- **Product review:** skipped. The diff touches the workflow, a test and docs, not what the CV says or how it renders.

## Self-review

- **What is published:** the same files the legacy build served, the whole tree minus dot-files, not only what the page needs. `tests/`, `scripts/` and `docs/` stay reachable on the site, as they were. Narrowing that is a separate decision about the public footprint, not made here. Observation.
- **Markdown:** the legacy build ran Jekyll, which turned `.md` files into pages. The workflow publishes them as they are. No page of the CV links to one. Observation.
- **`generated/*.pdf` are still committed.** The site now ships the PDFs CI built, and the committed copies only serve the repository view. Whether to stop committing them is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
