### PR TITLE
Render the page from CvDocument, like every other output

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,9 @@ Ports and adapters. `AGENTS.md` holds the product rules and the settled decision
 A CV is `profile × locale × layout`. `config/cv-manifest.json` declares the supported combinations;
 `ProfileResolver` reads `?profile=` and refuses an unknown one rather than falling back. Content
 lives in `profiles/<profile>/<locale>.json`, labels in `locales/<lang>/`, and `domain/CvDocument.js`
-normalises the two into the model every output boundary consumes.
+normalises the two into the model every output boundary consumes. On the page, `CVApplication` builds
+it once and hands it to the localizer, every renderer and Nerd Mode's editor, and
+`tests/PageRendersTheModel.test.js` fails when one of them reads the profile JSON instead (#81).
 
 There are **two artefacts and they do not share a DOM**: the page renders through `renderers/`,
 while the PDF is composed from the model by `adapters/PdfLayout.js` and written by pdfmake. That is

--- a/adapters/SwiftSourceLayout.js
+++ b/adapters/SwiftSourceLayout.js
@@ -60,6 +60,8 @@ const content = (value, kind, extra = {}) => ({ text: value, kind, ...extra });
 const between = (value) => content(value, 'plain');
 const clean = (value) => (value === undefined || value === null ? '' : String(value).trim());
 const list = (value) => (Array.isArray(value) ? value.filter(Boolean) : []);
+/** Who the CV is about: the model's identity, or nothing to show when there is none. */
+const identityOf = (data) => data.identity || {};
 
 /** A string literal. The quotes are syntax; what is between them is the data. */
 const quoted = (value, extra = {}) =>
@@ -122,7 +124,7 @@ export function swiftTypeName(name) {
 
 export class SwiftSourceLayout {
   /**
-   * @param {object} data - the profile, as the page renderers receive it
+   * @param {object} data - the model, `CvDocument`, as the page renderers receive it (#81)
    * @param {object} context - `t`, the translator, already bound by the caller
    * @returns {{ typeName: string, fileName: string, lines: object[], outline: object[],
    *   card: object }} `lines` are `{ depth, tokens }`, plus `heading` and `id` on a section mark
@@ -130,7 +132,7 @@ export class SwiftSourceLayout {
    *   `card` is what the preview shows
    */
   compose(data = {}, { t = (key) => key } = {}) {
-    const typeName = swiftTypeName(data.name);
+    const typeName = swiftTypeName(identityOf(data).name);
     const lines = [];
     const outline = [];
     const push = (depth, tokens = [], extra = {}) =>
@@ -195,8 +197,8 @@ export class SwiftSourceLayout {
   }
 
   identity(data) {
-    const name = clean(data.name);
-    const title = clean(data.title);
+    const name = clean(identityOf(data).name);
+    const title = clean(identityOf(data).title);
     return [
       ...(name
         ? [
@@ -212,9 +214,11 @@ export class SwiftSourceLayout {
   }
 
   profile(data) {
-    const [focus, summary, availability] = [data.subtitle, data.profile, data.availability].map(
-      clean
-    );
+    const [focus, summary, availability] = [
+      identityOf(data).subtitle,
+      data.profile,
+      identityOf(data).availability
+    ].map(clean);
 
     const lines = [];
     if (focus) lines.push([0, [...declaration('let', 'focus'), ...quoted(focus)]]);
@@ -234,7 +238,7 @@ export class SwiftSourceLayout {
     return this.collection(
       'experience',
       'Role',
-      list(data.relevant_experience).map((role) =>
+      list(data.experience).map((role) =>
         this.call(
           'Role',
           [
@@ -356,9 +360,9 @@ export class SwiftSourceLayout {
   }
 
   contact(data) {
-    const email = clean(data.email);
-    const phone = clean(data.phone);
-    const links = list(data.social)
+    const email = clean(identityOf(data).email);
+    const phone = clean(identityOf(data).phone);
+    const links = list(identityOf(data).social)
       .filter((link) => clean(link.url) !== '')
       .map((link) => {
         const address = readableAddress(link.url);
@@ -376,7 +380,7 @@ export class SwiftSourceLayout {
     return this.call(
       'Contact',
       [
-        ['location', data.location],
+        ['location', identityOf(data).location],
         ['email', email, email ? { element: 'a', href: `mailto:${email}` } : {}],
         ['phone', phone, phone ? { element: 'a', href: telephone(phone) } : {}],
         ['links', links]
@@ -449,9 +453,9 @@ export class SwiftSourceLayout {
    * card's details, so nobody who wants to call is kept from it.
    */
   card(data, t) {
-    const phone = clean(data.phone);
-    const email = clean(data.email);
-    const location = clean(data.location);
+    const phone = clean(identityOf(data).phone);
+    const email = clean(identityOf(data).email);
+    const location = clean(identityOf(data).location);
 
     const actions = [
       ...(phone
@@ -474,7 +478,7 @@ export class SwiftSourceLayout {
             }
           ]
         : []),
-      ...list(data.social)
+      ...list(identityOf(data).social)
         .filter((link) => clean(link.url) !== '' && clean(link.platform) !== '')
         .map((link) => ({
           icon: 'link',
@@ -505,6 +509,12 @@ export class SwiftSourceLayout {
       ? { title: phone, message: t('source.card.callJoke'), dismiss: t('source.card.callDismiss') }
       : null;
 
-    return { name: clean(data.name), title: clean(data.title), call, actions, rows };
+    return {
+      name: clean(identityOf(data).name),
+      title: clean(identityOf(data).title),
+      call,
+      actions,
+      rows
+    };
   }
 }

--- a/core/CVApplication.js
+++ b/core/CVApplication.js
@@ -1,4 +1,5 @@
 import { DataLoader } from './DataLoader.js';
+import { CvDocument } from '../domain/CvDocument.js';
 import { RendererContainer } from './RendererContainer.js';
 import { ErrorRenderer } from '../renderers/ErrorRenderer.js';
 
@@ -12,13 +13,15 @@ export class CVApplication {
     rendererContainer = new RendererContainer(),
     documentLocalizer = null,
     i18n = null,
-    errorRenderer = new ErrorRenderer()
+    errorRenderer = new ErrorRenderer(),
+    documentFactory = (data) => new CvDocument(data)
   ) {
     this.dataLoader = dataLoader;
     this.rendererContainer = rendererContainer;
     this.documentLocalizer = documentLocalizer;
     this.i18n = i18n;
     this.errorRenderer = errorRenderer;
+    this.documentFactory = documentFactory;
     this.isInitialized = false;
   }
 
@@ -40,8 +43,12 @@ export class CVApplication {
       const data = await this.dataLoader.loadCVData();
       this.currentData = data;
       this.root = root;
-      if (this.documentLocalizer) this.documentLocalizer.apply(root, data);
-      this.rendererContainer.renderAll(root, data);
+      // Every part of the page reads the model, as the PDF, the cover letter and the audits do: a default
+      // or a renamed key added to CvDocument reaches the page and the PDF alike (#81). The profile itself
+      // is returned, because the PDF exporter builds its own model from it.
+      const cv = this.documentFactory(data);
+      if (this.documentLocalizer) this.documentLocalizer.apply(root, cv);
+      this.rendererContainer.renderAll(root, cv);
       this.isInitialized = true;
       return data;
     } catch (error) {

--- a/core/DocumentLocalizer.js
+++ b/core/DocumentLocalizer.js
@@ -4,11 +4,11 @@ export class DocumentLocalizer {
     this.i18n = i18n;
   }
 
-  apply(root, data = {}) {
+  apply(root, cv = {}) {
     if (!root || !this.i18n) return;
 
     root.documentElement.lang = this.i18n.language;
-    root.title = this.i18n.t('meta.title', { name: data.name || '' });
+    root.title = this.i18n.t('meta.title', { name: cv.identity?.name || '' });
 
     root.querySelectorAll('[data-i18n]').forEach((element) => {
       const key = element.dataset.i18n;
@@ -22,7 +22,7 @@ export class DocumentLocalizer {
       element.dataset.i18nAttr.split(',').forEach((mapping) => {
         const [attribute, key] = mapping.split(':').map((part) => part.trim());
         if (attribute && key) {
-          element.setAttribute(attribute, this.i18n.t(key, { name: data.name || '' }));
+          element.setAttribute(attribute, this.i18n.t(key, { name: cv.identity?.name || '' }));
         }
       });
     });

--- a/renderers/ExperienceRenderer.js
+++ b/renderers/ExperienceRenderer.js
@@ -12,7 +12,7 @@ export class ExperienceRenderer extends BaseRenderer {
     const container = this.getElement(root, 'experience');
     if (!container) return;
 
-    this.renderItems(container, data.relevant_experience, (job) => this.createJobEntry(root, job));
+    this.renderItems(container, data.experience, (job) => this.createJobEntry(root, job));
   }
 
   createJobEntry(root, job) {
@@ -49,8 +49,6 @@ export class ExperienceRenderer extends BaseRenderer {
   }
 
   validate(data) {
-    return (
-      this.validateFields(data, ['relevant_experience']) && Array.isArray(data.relevant_experience)
-    );
+    return this.validateFields(data, ['experience']) && Array.isArray(data.experience);
   }
 }

--- a/renderers/HeaderRenderer.js
+++ b/renderers/HeaderRenderer.js
@@ -8,6 +8,7 @@ export class HeaderRenderer extends Renderer {
 
   render(root, data) {
     if (!this.validate(data)) return;
+    const { identity } = data;
 
     const nameElement = root.getElementById('name');
     const titleElement = root.getElementById('title');
@@ -16,18 +17,18 @@ export class HeaderRenderer extends Renderer {
     const locationElement = root.getElementById('location');
     const contactsElement = root.getElementById('contacts');
 
-    if (nameElement) nameElement.textContent = data.name || '';
-    if (titleElement) titleElement.textContent = data.title || '';
-    this.renderOptional(subtitleElement, data.subtitle);
-    this.renderOptional(availabilityElement, data.availability);
-    if (locationElement) locationElement.textContent = data.location || '';
+    if (nameElement) nameElement.textContent = identity.name || '';
+    if (titleElement) titleElement.textContent = identity.title || '';
+    this.renderOptional(subtitleElement, identity.subtitle);
+    this.renderOptional(availabilityElement, identity.availability);
+    if (locationElement) locationElement.textContent = identity.location || '';
 
     if (contactsElement) {
       const email = this.i18n ? this.i18n.t('contacts.email', { ns: 'cv' }) : 'Email';
       const phone = this.i18n ? this.i18n.t('contacts.phone', { ns: 'cv' }) : 'Phone';
       contactsElement.innerHTML = `
-        <strong>${email}:</strong> ${data.email || ''}<br>
-        <strong>${phone}:</strong> ${data.phone || ''}
+        <strong>${email}:</strong> ${identity.email || ''}<br>
+        <strong>${phone}:</strong> ${identity.phone || ''}
       `;
     }
   }
@@ -40,6 +41,9 @@ export class HeaderRenderer extends Renderer {
   }
 
   validate(data) {
-    return super.validate(data) && !!(data.name || data.title || data.email);
+    return (
+      super.validate(data) &&
+      !!(data.identity?.name || data.identity?.title || data.identity?.email)
+    );
   }
 }

--- a/renderers/SocialLinksRenderer.js
+++ b/renderers/SocialLinksRenderer.js
@@ -8,7 +8,7 @@ export class SocialLinksRenderer extends BaseRenderer {
     const container = this.querySelector(root, '.social-links');
     if (!container) return;
 
-    const anchors = data.social
+    const anchors = data.identity.social
       .filter((link) => !!link)
       .map((link) => this.createSocialLink(root, link));
 
@@ -32,6 +32,6 @@ export class SocialLinksRenderer extends BaseRenderer {
   }
 
   validate(data) {
-    return this.validateFields(data, ['social']) && Array.isArray(data.social);
+    return super.validate(data) && Array.isArray(data.identity?.social);
   }
 }

--- a/tests/CertificationsRenderer.test.js
+++ b/tests/CertificationsRenderer.test.js
@@ -1,5 +1,6 @@
 import { CertificationsRenderer } from '../renderers/CertificationsRenderer.js';
 import { JSDOM } from 'jsdom';
+import { fedTheModel } from './support/model.js';
 
 describe('CertificationsRenderer', () => {
   let document;
@@ -15,7 +16,7 @@ describe('CertificationsRenderer', () => {
       </html>
     `);
     document = dom.window.document;
-    renderer = new CertificationsRenderer();
+    renderer = fedTheModel(new CertificationsRenderer());
   });
 
   test('renders certifications with URLs correctly', () => {

--- a/tests/DocumentLocalizer.test.js
+++ b/tests/DocumentLocalizer.test.js
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom';
 import { DocumentLocalizer } from '../core/DocumentLocalizer.js';
+import { CvDocument } from '../domain/CvDocument.js';
 
 describe('DocumentLocalizer', () => {
   test('localizes text, attributes, metadata and HTML language', () => {
@@ -14,7 +15,7 @@ describe('DocumentLocalizer', () => {
     };
     const i18n = { language: 'de', t: (key) => messages[key] };
 
-    new DocumentLocalizer(i18n).apply(document, { name: 'Giovanni Trovato' });
+    new DocumentLocalizer(i18n).apply(document, new CvDocument({ name: 'Giovanni Trovato' }));
 
     expect(document.documentElement.lang).toBe('de');
     expect(document.title).toBe('Giovanni Trovato – Lebenslauf');

--- a/tests/EducationRenderer.test.js
+++ b/tests/EducationRenderer.test.js
@@ -1,5 +1,6 @@
 import { EducationRenderer } from '../renderers/EducationRenderer.js';
 import { JSDOM } from 'jsdom';
+import { fedTheModel } from './support/model.js';
 
 describe('EducationRenderer', () => {
   let document;
@@ -15,7 +16,7 @@ describe('EducationRenderer', () => {
       </html>
     `);
     document = dom.window.document;
-    renderer = new EducationRenderer();
+    renderer = fedTheModel(new EducationRenderer());
   });
 
   test('renders education entries correctly', () => {

--- a/tests/ExperienceRenderer.test.js
+++ b/tests/ExperienceRenderer.test.js
@@ -1,5 +1,6 @@
 import { ExperienceRenderer } from '../renderers/ExperienceRenderer.js';
 import { JSDOM } from 'jsdom';
+import { fedTheModel } from './support/model.js';
 
 describe('ExperienceRenderer', () => {
   let document;
@@ -15,7 +16,7 @@ describe('ExperienceRenderer', () => {
       </html>
     `);
     document = dom.window.document;
-    renderer = new ExperienceRenderer();
+    renderer = fedTheModel(new ExperienceRenderer());
   });
 
   test('holds every hyphenated compound on one line without touching the text', () => {

--- a/tests/HeaderRenderer.test.js
+++ b/tests/HeaderRenderer.test.js
@@ -1,5 +1,7 @@
 import { HeaderRenderer } from '../renderers/HeaderRenderer.js';
+import { CvDocument } from '../domain/CvDocument.js';
 import { JSDOM } from 'jsdom';
+import { fedTheModel } from './support/model.js';
 
 describe('HeaderRenderer', () => {
   let document;
@@ -20,7 +22,7 @@ describe('HeaderRenderer', () => {
       </html>
     `);
     document = dom.window.document;
-    renderer = new HeaderRenderer();
+    renderer = fedTheModel(new HeaderRenderer());
   });
 
   test('renders header information correctly', () => {
@@ -41,8 +43,8 @@ describe('HeaderRenderer', () => {
   });
 
   test('validates data correctly', () => {
-    expect(renderer.validate({ name: 'John' })).toBe(true);
-    expect(renderer.validate({})).toBe(false);
+    expect(renderer.validate(new CvDocument({ name: 'John' }))).toBe(true);
+    expect(renderer.validate(new CvDocument({}))).toBe(false);
     expect(renderer.validate(null)).toBe(false);
   });
 
@@ -69,9 +71,11 @@ describe('HeaderRenderer', () => {
   });
 
   test('localizes contact labels', () => {
-    const localized = new HeaderRenderer({
-      t: (key) => ({ 'contacts.email': 'E-Mail', 'contacts.phone': 'Telefon' })[key]
-    });
+    const localized = fedTheModel(
+      new HeaderRenderer({
+        t: (key) => ({ 'contacts.email': 'E-Mail', 'contacts.phone': 'Telefon' })[key]
+      })
+    );
     localized.render(document, { name: 'John', email: 'john@example.com', phone: '123' });
 
     expect(document.getElementById('contacts').textContent).toContain('E-Mail:');

--- a/tests/InterestsRenderer.test.js
+++ b/tests/InterestsRenderer.test.js
@@ -1,5 +1,6 @@
 import { InterestsRenderer } from '../renderers/InterestsRenderer.js';
 import { JSDOM } from 'jsdom';
+import { fedTheModel } from './support/model.js';
 
 describe('InterestsRenderer', () => {
   let document;
@@ -15,7 +16,7 @@ describe('InterestsRenderer', () => {
       </html>
     `);
     document = dom.window.document;
-    renderer = new InterestsRenderer();
+    renderer = fedTheModel(new InterestsRenderer());
   });
 
   const container = () => document.getElementById('interests');
@@ -62,7 +63,9 @@ describe('InterestsRenderer', () => {
 
 test('gives every interest its own element while the line still reads as it did', () => {
   document.body.innerHTML = '<section><div id="interests"></div></section>';
-  new InterestsRenderer().render(document, { interests: ['Robotics & IoT', 'Mountain Hiking'] });
+  fedTheModel(new InterestsRenderer()).render(document, {
+    interests: ['Robotics & IoT', 'Mountain Hiking']
+  });
   const chips = [...document.querySelectorAll('.interest-chip')].map((chip) => chip.textContent);
   expect(chips).toEqual(['Robotics & IoT', 'Mountain Hiking']);
   expect(document.querySelector('.interests-line').textContent).toBe(

--- a/tests/PageRendersTheModel.test.js
+++ b/tests/PageRendersTheModel.test.js
@@ -1,0 +1,126 @@
+/**
+ * @jest-environment node
+ */
+import { readFileSync } from 'node:fs';
+import { JSDOM } from 'jsdom';
+import { CVApplication } from '../core/CVApplication.js';
+import { DocumentLocalizer } from '../core/DocumentLocalizer.js';
+import { RendererContainer } from '../core/RendererContainer.js';
+import { CvDocument } from '../domain/CvDocument.js';
+import { CertificationsRenderer } from '../renderers/CertificationsRenderer.js';
+import { EducationRenderer } from '../renderers/EducationRenderer.js';
+import { ExperienceRenderer } from '../renderers/ExperienceRenderer.js';
+import { HeaderRenderer } from '../renderers/HeaderRenderer.js';
+import { InterestsRenderer } from '../renderers/InterestsRenderer.js';
+import { LanguagesRenderer } from '../renderers/LanguagesRenderer.js';
+import { ProfileRenderer } from '../renderers/ProfileRenderer.js';
+import { SkillsRenderer } from '../renderers/SkillsRenderer.js';
+import { SocialLinksRenderer } from '../renderers/SocialLinksRenderer.js';
+import { SourceRenderer } from '../renderers/SourceRenderer.js';
+
+// The PDF, the cover letter and the audits read CvDocument. The page's renderers used to read the
+// profile JSON as loaded, each its own raw keys, so a default or a renamed key added to the model reached
+// one artefact and not the other: #35 found the visible case, interests on the page only (#81). Every
+// part of the page reads the model now, and this is what fails when one reads the profile again.
+const read = (path) => readFileSync(new URL(`../${path}`, import.meta.url), 'utf8');
+const profile = JSON.parse(read('profiles/general/en.json'));
+const page = read('index.html');
+const at = { url: 'http://localhost/index.html?layout=nerd' };
+const i18n = { language: 'en', t: (key) => key };
+
+/** The model, noting every key read from it that it does not have: a raw one such as `relevant_experience`. */
+const watched = (model, strays) =>
+  new Proxy(model, {
+    get(target, key, receiver) {
+      if (typeof key === 'string' && !(key in target)) strays.add(key);
+      return Reflect.get(target, key, receiver);
+    }
+  });
+
+// What script.js registers, in its order.
+const RENDERERS = [
+  ['HeaderRenderer', () => new HeaderRenderer(i18n)],
+  ['SocialLinksRenderer', () => new SocialLinksRenderer()],
+  ['ProfileRenderer', () => new ProfileRenderer()],
+  ['ExperienceRenderer', () => new ExperienceRenderer(i18n)],
+  ['EducationRenderer', () => new EducationRenderer()],
+  ['CertificationsRenderer', () => new CertificationsRenderer()],
+  ['SkillsRenderer', () => new SkillsRenderer()],
+  ['LanguagesRenderer', () => new LanguagesRenderer()],
+  ['InterestsRenderer', () => new InterestsRenderer()],
+  ['SourceRenderer', () => new SourceRenderer(i18n)]
+];
+
+describe('the page reads the model, never the profile', () => {
+  test('the watch notes a raw profile key read from the model', () => {
+    const strays = new Set();
+    const cv = watched(new CvDocument(profile), strays);
+
+    expect(cv.experience).toEqual(profile.relevant_experience);
+    expect(cv.relevant_experience).toBeUndefined();
+    expect([...strays]).toEqual(['relevant_experience']);
+  });
+
+  test.each(RENDERERS)('%s reads only keys the model has', (name, make) => {
+    const { document } = new JSDOM(page, at).window;
+    const strays = new Set();
+
+    make().render(document, watched(new CvDocument(profile), strays));
+
+    expect([...strays]).toEqual([]);
+  });
+
+  // A renderer that returned early would read nothing, and pass the watch above.
+  test('rendered from the model, the page carries the profile', () => {
+    const { document } = new JSDOM(page, at).window;
+    const cv = new CvDocument(profile);
+    for (const [, make] of RENDERERS) make().render(document, cv);
+    const text = document.body.textContent;
+
+    for (const written of [
+      profile.name,
+      profile.title,
+      profile.relevant_experience[0].company,
+      profile.education[0].degree,
+      profile.languages[0].name,
+      profile.certifications[0].name,
+      profile.skills[0].items[0].name
+    ]) {
+      expect(text).toContain(written);
+    }
+    expect(
+      document.querySelector(`.social-links a[href="${profile.social[0].url}"]`)
+    ).not.toBeNull();
+    expect(document.getElementById('source-code').textContent).toContain(profile.name);
+  });
+
+  test('the localizer names the candidate from the model', () => {
+    const { document } = new JSDOM(page).window;
+    const strays = new Set();
+    const naming = { language: 'en', t: (key, values) => `${key} ${values?.name ?? ''}` };
+
+    new DocumentLocalizer(naming).apply(document, watched(new CvDocument(profile), strays));
+
+    expect(document.title).toContain(profile.name);
+    expect([...strays]).toEqual([]);
+  });
+
+  // The PDF exporter builds its own model from the profile, so the profile is what the page keeps.
+  test('CVApplication hands the localizer and every renderer the model, and returns the profile', async () => {
+    const received = [];
+    const app = new CVApplication({ loadCVData: async () => profile }, new RendererContainer(), {
+      apply: (root, cv) => received.push(['localizer', cv instanceof CvDocument])
+    });
+    app.registerRenderer('probe', {
+      render: (root, cv) => received.push(['renderer', cv instanceof CvDocument])
+    });
+
+    const returned = await app.initialize(new JSDOM(page).window.document);
+
+    expect(received).toEqual([
+      ['localizer', true],
+      ['renderer', true]
+    ]);
+    expect(returned).toBe(profile);
+  });
+});

--- a/tests/ProfileRenderer.test.js
+++ b/tests/ProfileRenderer.test.js
@@ -1,5 +1,6 @@
 import { ProfileRenderer } from '../renderers/ProfileRenderer.js';
 import { JSDOM } from 'jsdom';
+import { fedTheModel } from './support/model.js';
 
 describe('ProfileRenderer', () => {
   let document;
@@ -15,7 +16,7 @@ describe('ProfileRenderer', () => {
       </html>
     `);
     document = dom.window.document;
-    renderer = new ProfileRenderer();
+    renderer = fedTheModel(new ProfileRenderer());
   });
 
   test('renders profile text correctly', () => {

--- a/tests/SkillsRenderer.test.js
+++ b/tests/SkillsRenderer.test.js
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom';
 import { SkillsRenderer } from '../renderers/SkillsRenderer.js';
+import { fedTheModel } from './support/model.js';
 
 describe('SkillsRenderer', () => {
   const document = new JSDOM('<!doctype html><html><body><div id="skills"></div></body></html>')
@@ -10,7 +11,7 @@ describe('SkillsRenderer', () => {
   });
 
   test('renders grouped skills as compact categorized text', () => {
-    new SkillsRenderer().render(document, {
+    fedTheModel(new SkillsRenderer()).render(document, {
       skills: [
         {
           category: 'iOS',
@@ -30,7 +31,7 @@ describe('SkillsRenderer', () => {
   });
 
   test('keeps the legacy flat profile readable without ratings', () => {
-    new SkillsRenderer().render(document, {
+    fedTheModel(new SkillsRenderer()).render(document, {
       skills: [
         { name: 'Swift', level: 5 },
         { name: 'Git', level: 5 }
@@ -47,7 +48,7 @@ test('gives every skill its own element while the line still reads as it did', (
   // separators stay real text nodes, so copy/paste and any parser still see "Swift, SwiftUI"
   // rather than "SwiftSwiftUI": the same failure the PDF hit on hyphenated compounds.
   document.body.innerHTML = '<div id="skills"></div>';
-  new SkillsRenderer().render(document, {
+  fedTheModel(new SkillsRenderer()).render(document, {
     skills: [{ category: 'iOS', items: [{ name: 'Swift' }, { name: 'SwiftUI' }] }]
   });
   const chips = [...document.querySelectorAll('.skill-chip')].map((chip) => chip.textContent);

--- a/tests/SourceRenderer.test.js
+++ b/tests/SourceRenderer.test.js
@@ -1,5 +1,6 @@
 import { JSDOM } from 'jsdom';
 import { SourceRenderer } from '../renderers/SourceRenderer.js';
+import { fedTheModel } from './support/model.js';
 
 const labels = {
   'source.marks.profile': 'Profile',
@@ -58,7 +59,7 @@ describe('SourceRenderer', () => {
     </body></html>`).window.document;
   });
 
-  const render = () => new SourceRenderer(i18n).render(document, profile);
+  const render = () => fedTheModel(new SourceRenderer(i18n)).render(document, profile);
   const code = () => document.getElementById('source-code');
 
   test('writes the syntax as drawing instructions and the CV as text', () => {
@@ -225,7 +226,7 @@ describe('SourceRenderer', () => {
   test('answers a tap on call with an alert: the number, and a nudge to dial it yourself', () => {
     // The candidate's easter egg. It is a real dialog, so it takes focus, is announced and closes
     // on Escape, and the button says what it opens.
-    new SourceRenderer(i18n).render(document, { ...profile, phone: '+49 30 1234' });
+    fedTheModel(new SourceRenderer(i18n)).render(document, { ...profile, phone: '+49 30 1234' });
 
     const call = document.querySelector('#source-card .app-action[data-icon="phone"]');
     expect([
@@ -287,7 +288,7 @@ describe('SourceRenderer — the section in view', () => {
     window = dom.window;
   });
 
-  const render = () => new SourceRenderer(i18n).render(document, profile);
+  const render = () => fedTheModel(new SourceRenderer(i18n)).render(document, profile);
   const place = (element, rect) => {
     element.getBoundingClientRect = () => ({ top: 0, bottom: 0, left: 0, right: 0, ...rect });
   };

--- a/tests/SwiftSourceLayout.test.js
+++ b/tests/SwiftSourceLayout.test.js
@@ -2,6 +2,7 @@ import fs from 'fs';
 import path from 'path';
 import { fileURLToPath } from 'url';
 import { SwiftSourceLayout } from '../adapters/SwiftSourceLayout.js';
+import { composingTheModel } from './support/model.js';
 
 const labels = {
   'source.marks.profile': 'Profile',
@@ -100,7 +101,7 @@ const textOf = (line) =>
 const textLinesOf = ({ lines }) => lines.map(textOf).filter(Boolean);
 
 describe('SwiftSourceLayout', () => {
-  const layout = new SwiftSourceLayout();
+  const layout = composingTheModel(new SwiftSourceLayout());
 
   test('reads the CV as a Swift file: who, the profile, the evidence, then how to reach them', () => {
     expect(sourceOf(layout.compose(profile, { t }))).toBe(

--- a/tests/socialLinksRenderer.test.js
+++ b/tests/socialLinksRenderer.test.js
@@ -1,5 +1,6 @@
 import { SocialLinksRenderer } from '../renderers/SocialLinksRenderer.js';
 import { JSDOM } from 'jsdom';
+import { fedTheModel } from './support/model.js';
 
 describe('SocialLinksRenderer', () => {
   let document;
@@ -15,7 +16,7 @@ describe('SocialLinksRenderer', () => {
       </html>
     `);
     document = dom.window.document;
-    renderer = new SocialLinksRenderer();
+    renderer = fedTheModel(new SocialLinksRenderer());
   });
 
   const links = () => document.querySelector('.social-links').querySelectorAll('a');

--- a/tests/support/model.js
+++ b/tests/support/model.js
@@ -1,0 +1,37 @@
+import { CvDocument } from '../../domain/CvDocument.js';
+
+/**
+ * Whatever a proxied method returns, bound to the object itself, so a method calling another through
+ * `this` never meets the proxy again.
+ */
+const forward = (target, key) => {
+  const value = Reflect.get(target, key);
+  return typeof value === 'function' ? value.bind(target) : value;
+};
+
+/**
+ * A renderer fed the way the page feeds it: the model `CVApplication` builds from the profile, never the
+ * profile itself (#81). Tests keep writing profile JSON, the input a person writes.
+ * @param {object} renderer - A renderer
+ * @returns {object} The same renderer, whose `render` receives `new CvDocument(profile)`
+ */
+export const fedTheModel = (renderer) =>
+  new Proxy(renderer, {
+    get: (target, key) =>
+      key === 'render'
+        ? (root, profile) => target.render(root, new CvDocument(profile))
+        : forward(target, key)
+  });
+
+/**
+ * A layout composing from the model built from the profile a test writes, as `SourceRenderer` hands it.
+ * @param {object} layout - A layout with `compose(model, options)`
+ * @returns {object} The same layout, whose `compose` receives `new CvDocument(profile)`
+ */
+export const composingTheModel = (layout) =>
+  new Proxy(layout, {
+    get: (target, key) =>
+      key === 'compose'
+        ? (profile, options) => target.compose(new CvDocument(profile), options)
+        : forward(target, key)
+  });


### PR DESCRIPTION
> **The adversarial review has not run yet.** Codex is at its usage limit until 15 September, 09:56. The review is queued for then, and this pull request stays a draft until its findings are answered.

## What

`CLAUDE.md` called `domain/CvDocument.js` "the model every output boundary consumes". The PDF, the cover letter and the audits did consume it; the page did not.

- **How the page read the profile.** `CVApplication` handed every renderer the profile JSON as loaded, and each renderer read its own raw keys.
- **What that cost.** A default or a renamed key added to the model reached one artefact and not the other; #35 was the visible case.

On #81 the owner chose the first correction: the page renders from the model.

Refs #81

## Changes

- **`core/CVApplication.js`** builds the model once (`documentFactory`, `CvDocument` by default) and hands it to the localizer and to every renderer. It still returns the profile itself: the PDF exporter builds its own model from it, so `script.js` does not change.
- **Readers of keys the model renames:**
  - `renderers/HeaderRenderer.js`: `name`, `title`, `subtitle`, `availability`, `location`, `email` and `phone` become `identity.*`;
  - `renderers/SocialLinksRenderer.js`: `social` becomes `identity.social`;
  - `renderers/ExperienceRenderer.js`: `relevant_experience` becomes `experience`;
  - `adapters/SwiftSourceLayout.js`, Nerd Mode's editor: the identity fields, read through `identityOf`, and `relevant_experience` becomes `experience`;
  - `core/DocumentLocalizer.js`: the name in the page title comes from `identity.name`.
- **The other renderers** read keys the model keeps under the same names (`profile`, `education`, `certifications`, `skills`, `languages`, `interests`). They needed no change, and now receive the model too.
- **`CLAUDE.md`**: the data-flow paragraph says what the page does, and names the test.

## The test that fails when a renderer reads the profile again

`tests/PageRendersTheModel.test.js` checks four things:

- **Every renderer reads only the model.** It renders each renderer `script.js` registers into `index.html`, from the real profile's model. The model sits behind a proxy that records every key read that the model does not have, such as `relevant_experience`, `name` or `social`. The test expects none.
- **The page still carries the profile.** Rendered from the model, the page must contain the name, the title, the first employer, the degree, a language, a certification, a skill, a social link, and the name in Nerd Mode's source. A renderer that returned early cannot pass by reading nothing.
- **The localizer** reads the candidate's name from the model.
- **`CVApplication`** hands the localizer and every renderer a `CvDocument`, and returns the profile.

Before the change, 7 of its 14 tests failed: `HeaderRenderer`, `SocialLinksRenderer`, `ExperienceRenderer` and `SourceRenderer` read raw keys, and the localizer and `CVApplication` passed the profile along. After the change, all 14 pass.

The existing renderer, layout and localizer tests now hand what they render the model built from the profile they write (`tests/support/model.js`), as the page does:

- fed the model while the code still read the profile, 44 of their 79 tests failed;
- after the change, all pass.

One assertion changed meaning and was rewritten: `HeaderRenderer.validate` is now checked against a model, not a raw object.

## Once loaded, the page is what it was

- **Screen.** Full-page screenshots of all three layouts, at 1280px and 390px, are byte-identical to `main`.
- **Print.** Printed from the same browser, each layout keeps two pages, with identical extracted text and identical pixels on every page at 50dpi.
- **Audits.** `npm run audit:screen` scores 6/6 with a layout shift of 0.000 everywhere, and `npm run audit:print` scores 12/12 on all three layouts. The committed reports are unchanged.
- **Gates.** `npm test`: 554 passed.

## Reviews

- **Adversarial (codex-cli):** not run yet; queued for the usage-limit reset on 15 September.
- **Product review:** not run. The diff touches `renderers/`, which is on the list in `AGENTS.md`. But the rendered artefact is byte-identical to `main` on screen at both widths and in print, so a review would read `main`'s CV.

## Self-review

- **`adapters/SwiftSourceLayout.js`:** `identityOf` falls back to an empty identity, so `compose({})` still works. A caller that passed the raw profile would get an empty identity without complaint. `SourceRenderer` is the only caller, and the new test covers it. Observation.
- **`core/CVApplication.js`:** `documentFactory` is a sixth positional constructor argument, following the five before it. Observation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
